### PR TITLE
Make pip/setup.py install dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ htmlcov/
 dist
 .pybuild
 compat/litmus-*.tar.gz
+*.egg*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 install:
   - pip install pip --upgrade
   - sudo apt-get install -qq libneon27-dev
-  - pip install -r requirements.txt
+  - python setup.py develop
 script:
   - make check
   - make check-litmus

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo apt install python3-dulwich python3-defusedxml python3-icalendar
 Or to install them using pip:
 
 ```shell
-pip install -r requirements.txt
+python setup.py develop
 ```
 
 Running

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-dulwich
-icalendar
-defusedxml

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,3 @@ envlist = py35, p36
 commands = make check
 recreate = True
 whitelist_externals = make
-deps = -rrequirements.txt


### PR DESCRIPTION
Use `setuptools` with `install_requires` so that running pip or `setup.py` directly will install all dependencies.