### PR TITLE
Only return path from href. fixes #90

### DIFF
--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -1093,7 +1093,9 @@ def create_href(href, base_href=None):
 
 
 def read_href_element(et):
-    return urllib.parse.unquote(et.text)
+    el = urllib.parse.unquote(et.text)
+    el = urllib.parse.urlsplit(el)
+    return el.path
 
 
 class ExpandPropertyReporter(Reporter):


### PR DESCRIPTION
If the href contains a full url including hostname, as akonadi sends them, split them of and return only the path.