### PR TITLE
[WIP] Add commit metadata from User-Agent

### DIFF
--- a/xandikos/author.py
+++ b/xandikos/author.py
@@ -1,0 +1,38 @@
+# Xandikos
+# Copyright (C) 2016-2017 Jelmer Vernooĳ <jelmer@jelmer.uk>, et al.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 3
+# of the License or (at your option) any later version of
+# the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301, USA.
+
+"""Currently called author to not make a huge delta, but already going more in
+the direction of processing anything from the environment into information that
+goes into the commit"""
+
+from typing import Optional
+
+class Author:
+    @classmethod
+    def from_request(cls, request):
+        s = cls()
+        s._request = request
+        return s
+
+    def as_git_trailers(self) -> str:
+        trailers = {k: v for (k, v) in self._request.headers.items() if k.lower() in ('user-agent', )}
+        return "\n".join("%s: %s" % (k, v) for (k, v) in trailers.items())
+
+    def as_git_author(self) -> Optional[str]:
+        return None

--- a/xandikos/store/git.py
+++ b/xandikos/store/git.py
@@ -661,6 +661,11 @@ class TreeGitStore(GitStore):
         return index[name].sha.decode('ascii')
 
     def _commit_tree(self, index, message, author=None):
+        if author is not None:
+            trailer = author.as_git_trailers().encode(DEFAULT_ENCODING)
+            if trailer is not None:
+                message = message + b"\n\n" + trailer
+            author = author.as_git_author()
         tree = index.commit(self.repo.object_store)
         return self.repo.do_commit(message=message, author=author, tree=tree)
 

--- a/xandikos/tests/test_webdav.py
+++ b/xandikos/tests/test_webdav.py
@@ -213,7 +213,7 @@ class WebTests(WebTestCase):
             async def get_etag(self):
                 return '"foo"'
 
-            def delete_member(unused_self, name, etag=None):
+            def delete_member(unused_self, name, etag=None, author=None):
                 self.assertEqual(name, 'resource')
         app = self.makeApp({'/': TestResource(), '/resource': TestResource()},
                            [])

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -282,10 +282,10 @@ class StoreBasedCollection(object):
             return self._get_subcollection(name)
         raise KeyError(name)
 
-    def delete_member(self, name, etag=None):
+    def delete_member(self, name, etag=None, author=None):
         assert name != ''
         try:
-            self.store.delete_one(name, etag=extract_strong_etag(etag))
+            self.store.delete_one(name, etag=extract_strong_etag(etag), author=author)
         except NoSuchItem:
             # TODO: Properly allow removing subcollections
             # self.get_subcollection(name).destroy()
@@ -613,9 +613,9 @@ class CollectionSetResource(webdav.Collection):
         # TODO(jelmer): Find last modified time using store function
         raise KeyError
 
-    def delete_member(self, name, etag=None):
+    def delete_member(self, name, etag=None, author=None):
         # This doesn't have any non-collection members.
-        self.get_member(name).destroy()
+        self.get_member(name).destroy(author)
 
     def destroy(self):
         p = self.backend._map_to_file_path(self.relpath)
@@ -690,9 +690,9 @@ class RootPage(webdav.Resource):
     def get_member(self, name):
         return self.backend.get_resource('/' + name)
 
-    def delete_member(self, name, etag=None):
+    def delete_member(self, name, etag=None, author=None):
         # This doesn't have any non-collection members.
-        self.get_member('/' + name).destroy()
+        self.get_member('/' + name).destroy(author)
 
     def get_is_executable(self):
         return False

--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -39,6 +39,8 @@ from defusedxml.ElementTree import fromstring as xmlparse
 # Hmm, defusedxml doesn't have XML generation functions? :(
 from xml.etree import ElementTree as ET
 
+from xandikos.author import Author
+
 DEFAULT_ENCODING = 'utf-8'
 COLLECTION_RESOURCE_TYPE = '{DAV:}collection'
 PRINCIPAL_RESOURCE_TYPE = '{DAV:}principal'
@@ -832,7 +834,7 @@ class Collection(Resource):
         """
         raise NotImplementedError(self.get_member)
 
-    def delete_member(self, name, etag=None):
+    def delete_member(self, name, etag=None, author=None):
         """Delete a member with a specific name.
 
         :param name: Member name
@@ -1445,6 +1447,7 @@ class DeleteMethod(Method):
 
     async def handle(self, request, environ, app):
         unused_href, path, r = app._get_resource_from_environ(request, environ)
+        author = Author.from_request(request)
         if r is None:
             return _send_not_found(request)
         container_path, item_name = posixpath.split(path.rstrip('/'))
@@ -1455,7 +1458,7 @@ class DeleteMethod(Method):
         if_match = request.headers.get('If-Match', None)
         if if_match is not None and not etag_matches(if_match, current_etag):
             return Response(status=412, reason='Precondition Failed')
-        pr.delete_member(item_name, current_etag)
+        pr.delete_member(item_name, current_etag, author=author)
         return Response(status=204, reason='No Content')
 
 


### PR DESCRIPTION
This is a work-in-progress PR demonstrating the direction in which I'd like to fix https://github.com/jelmer/xandikos/issues/113.

To represent the attributes of the requester, an Author class (name may not fit perfectly, but it aligns with what the variable is called all around so far) is introduced. This will (in later authenticated cases) contain the user identifier, but primarily now contains the User-Agent. Unless xandikos does authentication itself, it won't contain authentication information.

To support Xanthikos' modular approach, interaction with it is centered around named access functions; for the (currently only supported?) case of a WebDav front-end on a Git back-end, an Author can be created `from_request` (extracting the User-Agent, and in future things like the user name / OpenID / certificate details). Back-ends would use dedicated formaters to place the information in whatever they take for storage. For git, both trailers and commit author information can be populated; additional fields may make sense later (eg. extracting the author time stamp's time zone into the change timestamp, if that's sent by user agents).

Plan for the development of this PR is to (hereby) ask for preliminary review of the approach taken (primarily the presence and use of the Author class), and to add author argument passing-along where the chain of author=author arguments is incomplete yet.