### PR TITLE
Query component's SUMMARY in ICalendarFile.describe()

### DIFF
--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -798,7 +798,7 @@ class ICalendarFile(File):
         else:
             for component in subcomponents:
                 try:
-                    return describe_component(component)
+                    return component["SUMMARY"]
                 except KeyError:
                     pass
         return super(ICalendarFile, self).describe(name)


### PR DESCRIPTION
Function describe_component() will never raise KeyError, so its usage in
ICalendarFile.describe() seems wrong as the method will then always use
the first component of subcomponents in the loop. This is problematic
when, e.g., the first subcomponent is a VTIMEZONE element which will
have no SUMMARY because the resulting git commit for a deletion will
look like "Delete calendar item" instead of "Delete <event title>".

This partially reverts 9db57a8bc6dcd67411999530203d85a8718e6b4b.