### PR TITLE
Always read the entire request body in `_readBody`

### DIFF
--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -1474,11 +1474,7 @@ def apply_modify_prop(el, href, resource, properties):
 
 
 async def _readBody(request):
-    request_body_size = request.content_length
-    if request_body_size is None:
-        return [await request.content.read()]
-    else:
-        return [await request.content.read(request_body_size)]
+    return [await request.content.read()]
 
 
 async def _readXmlBody(


### PR DESCRIPTION
aiohttp's `StreamReader.read(n)` method reads *up to* n bytes, but may
return fewer bytes if the request is still in flight.  The only sure way
to read the entire request payload is to not provide an argument to
`read()` (or to pass -1, which is the default and tells `read()` to read
until EOF is seen).