### PR TITLE
set port number to None when listening on unix socket

### DIFF
--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -1288,9 +1288,11 @@ def main(argv):
     if "/" in options.listen_address:
         socket_path = options.listen_address
         listen_address = None
+        listen_port = None # otherwise aiohttp also listens on its default host
         logging.info("Listening on unix domain socket %s", socket_path)
     else:
         listen_address = options.listen_address
+        listen_port = options.port
         socket_path = None
         logging.info("Listening on %s:%s", listen_address, options.port)
 
@@ -1334,7 +1336,7 @@ def main(argv):
         else:
             avahi_register(options.port, options.route_prefix)
 
-    web.run_app(app, port=options.port, host=listen_address, path=socket_path)
+    web.run_app(app, port=listen_port, host=listen_address, path=socket_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For `aiohttp.web.run_app` to only listen on a UNIX socket its port must also be
None, see <https://github.com/aio-libs/aiohttp/blob/742a8b6/aiohttp/web.py#L353>.

If port is not None, `aiohttp.web.run` also listens on its default host, that
is 0.0.0.0. Because `options.path` defaulted to 8080 Xandikos always also
listened on 0.0.0.0:8080 when instructed to use a UNIX socket.

Come to think about it, this is actually a security nightmare.