### PR TITLE
add support for systemd socket activation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(name="xandikos",
       ],
       extras_require={
           'prometheus': ['prometheus_client'],
+          'systemd': ['systemd_python'],
       },
       packages=find_packages(),
       package_data={'xandikos': ['templates/*.html']},


### PR DESCRIPTION
Add systemd-python as optional dependency and if it can be imported receive file descriptors from `systemd.daemon.listen_fds`.