### PR TITLE
Remove unnecessary #noqa comments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name="xandikos",
       test_suite='xandikos.tests.test_suite',
       classifiers=[
           'Development Status :: 4 - Beta',
-          'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',  # noqa
+          'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',

--- a/xandikos/sync.py
+++ b/xandikos/sync.py
@@ -54,7 +54,7 @@ class SyncCollectionReporter(webdav.Reporter):
 
     name = "{DAV:}sync-collection"
 
-    @webdav.multistatus  # noqa: C901
+    @webdav.multistatus
     async def report(  # noqa: C901
         self,
         environ,

--- a/xandikos/tests/test_web.py
+++ b/xandikos/tests/test_web.py
@@ -63,7 +63,7 @@ class CalendarCollectionTests(unittest.TestCase):
 
     def test_description(self):
         self.store.set_description("foo")
-        self.assertEquals("foo", self.cal.get_calendar_description())
+        self.assertEqual("foo", self.cal.get_calendar_description())
 
     def test_color(self):
         self.assertRaises(KeyError, self.cal.get_calendar_color)


### PR DESCRIPTION
Remove unnecessary #noqa comments.


This merge proposal was created automatically by the [Janitor bot](https://janitor.jelmer.uk/yesqa).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.jelmer.uk/yesqa.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.jelmer.uk/yesqa/pkg/xandikos/41925bf7-df25-4d06-9db9-bcf44abf948c.