### PR TITLE
Dockerfile: Fix ENTRYFILE so '--default' executes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ ADD . /code
 WORKDIR /code
 VOLUME /data
 EXPOSE 8000
-ENTRYPOINT python3 -m xandikos.web --port=8000 --listen-address=0.0.0.0 -d/data
-CMD "--defaults"
+ENTRYPOINT ["python3", "-m", "xandikos.web", "--port=8000", "--listen-address=0.0.0.0", "-d", "/data"]
+CMD ["--defaults"]


### PR DESCRIPTION
Fixing ENTRYFILE as discussed.  

ENTRYPOINT string should be an array when CMD is being used to load arguments, or else CMD items will not be processed. 

#145 