### PR TITLE
Create and select user_principal based on web authenticated user.

### DIFF
--- a/examples/xandikos.nginx.conf
+++ b/examples/xandikos.nginx.conf
@@ -18,6 +18,7 @@ server {
     location / {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Remote-User $remote_user;
         proxy_redirect off;
         proxy_buffering off;
         proxy_pass http://xandikos;

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -1030,6 +1030,14 @@ class XandikosBackend(webdav.Backend):
             except KeyError:
                 return None
 
+    def set_principal(self, user):
+        principal = "/%s/" % user
+        if not self.get_resource(principal):
+            if os.getenv("AUTOCREATE"):
+                self.create_principal(
+                    principal, create_defaults=True
+                )
+        self._mark_as_principal(principal)
 
 class XandikosApp(webdav.WebDAVApp):
     """A wsgi App that provides a Xandikos web server."""

--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -2069,7 +2069,12 @@ class WebDAVApp(object):
             logging.debug('SCRIPT_NAME not set; assuming "".')
             environ["SCRIPT_NAME"] = ""
         request = WSGIRequest(environ)
+        remote_user = environ.get("HTTP_X_REMOTE_USER")
         environ = {"SCRIPT_NAME": environ["SCRIPT_NAME"]}
+        if remote_user:
+            environ["REMOTE_USER"] = remote_user
+            self.backend.set_principal(remote_user)
+
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:


### PR DESCRIPTION
I'm not expecting this to get merged right now. Just putting it here for a place holder and feedback. Will begin working on get_resource() ACLS.

Also updates nginx example to pass $remote_user as HTTP_X_REMOTE_USER from a proxy.