### PR TITLE
Fix cross-references in documentation

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -1,3 +1,5 @@
+.. _getting-started:
+
 Getting Started
 ===============
 
@@ -5,7 +7,7 @@ Xandikos can either be run in a container (e.g. in docker or Kubernetes) or
 outside of a container.
 
 It is recommended that you run it behind a reverse proxy, since Xandikos by
-itself does provide authentication support. See `reverse-proxy` for details.
+itself does provide authentication support. See :ref:`reverse-proxy` for details.
 
 Running from systemd
 --------------------

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -7,7 +7,8 @@ Xandikos can either be run in a container (e.g. in docker or Kubernetes) or
 outside of a container.
 
 It is recommended that you run it behind a reverse proxy, since Xandikos by
-itself does provide authentication support. See :ref:`reverse-proxy` for details.
+itself does not provide authentication support. See :ref:`reverse-proxy` for
+details.
 
 Running from systemd
 --------------------

--- a/docs/source/reverse-proxy.rst
+++ b/docs/source/reverse-proxy.rst
@@ -1,3 +1,5 @@
+.. _reverse-proxy:
+
 Running behind a reverse proxy
 ==============================
 
@@ -26,7 +28,7 @@ Example: Kubernetes ingress
 
 Here is an example configuring Xandikos to listen on ``/dav`` using the
 Kubernetes nginx ingress controller. Note that this relies on the
-appropriate server being set up in kubernetes (see `getting-started`) and
+appropriate server being set up in kubernetes (see :ref:`getting-started`) and
 the ``my-htpasswd`` secret being present and having a htpasswd like file in it.
 
 .. literalinclude:: ../../examples/xandikos-ingress.k8s.yaml


### PR DESCRIPTION
We add the [:ref: role][] in references and add corresponding labels before
respective section titles to fix missing links in/to getting started and reverse proxy pages. 

[:ref: role]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref