### PR TITLE
Update ./bin/xandikos to treat main() as a coroutine

### DIFF
--- a/bin/xandikos
+++ b/bin/xandikos
@@ -18,6 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA  02110-1301, USA.
 
+import asyncio
 import os
 import sys
 
@@ -28,4 +29,4 @@ if os.path.join(os.path.dirname(__file__), "..", "xandikos"):
 
 from xandikos.__main__ import main
 
-sys.exit(main(sys.argv[1:]))
+sys.exit(asyncio.run(main(sys.argv[1:])))

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -1558,4 +1558,4 @@ async def main(argv=None):  # noqa: C901
 if __name__ == "__main__":
     import sys
 
-    asyncio.run(main(sys.argv[1:]))
+    sys.exit(asyncio.run(main(sys.argv[1:])))


### PR DESCRIPTION
Update ./bin/xandikos to treat main() as a coroutine

Fixes #192
