### PR TITLE
Make xandikos.__main__:main sync, and use it in console_scripts entrypoint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ python_requires = >=3.9
 
 [options.entry_points]
 console_scripts =
-    xandikos = xandikos.web:main
+    xandikos = xandikos.__main__:main
 
 [options.extras_require]
 prometheus = aiohttp_openmetrics

--- a/xandikos/__main__.py
+++ b/xandikos/__main__.py
@@ -22,14 +22,14 @@
 import asyncio
 
 
-async def main(argv):
+def main(argv=None):
     # For now, just invoke xandikos.web
     from .web import main
 
-    return await main(argv)
+    return asyncio.run(main(argv))
 
 
 if __name__ == "__main__":
     import sys
 
-    sys.exit(asyncio.run(main(sys.argv)))
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Make xandikos.__main__:main sync, and use it in console_scripts entrypoint

Fixes #213
