### PR TITLE
Be consistent in the way indexes are passed around

### DIFF
--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -507,7 +507,8 @@ class TextMatcher(object):
 
     def match_indexes(self, indexes: SubIndexes):
         return any(
-            self.match(self.type_fn.from_ical(k)) for k in indexes[None])
+            self.match(self.type_fn(self.type_fn.from_ical(k)))
+            for k in indexes[None])
 
     def match(self, prop: Union[vText, vCategory, str]):
         if isinstance(prop, vText):

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -43,6 +43,7 @@ from xandikos.store import (
     Indexes,
     IndexKey,
     IndexValue,
+    IndexValueIterator,
     InvalidFileContents,
 )
 
@@ -808,7 +809,10 @@ class CalendarFilter(Filter):
         self.children.append(ret)
         return ret
 
-    def check(self, name, file):
+    def check(self, name: str, file: File) -> bool:
+        if not isinstance(file, ICalendarFile):
+            return False
+
         c = file.calendar
         if c is None:
             return False
@@ -827,7 +831,7 @@ class CalendarFilter(Filter):
                 return False
         return True
 
-    def check_from_indexes(self, name, indexes):
+    def check_from_indexes(self, name: str, indexes: Indexes) -> bool:
         for child_filter in self.children:
             try:
                 if not child_filter.match_indexes(indexes, self.tzify):
@@ -928,9 +932,10 @@ class ICalendarFile(File):
                 pass
         raise KeyError
 
-    def _get_index(self, key):
+    def _get_index(self, key: IndexKey) -> IndexValueIterator:
         todo = [(self.calendar, key.split("/"))]
         rest = []
+        c: Component
         while todo:
             (c, segments) = todo.pop(0)
             if segments and segments[0].startswith("C="):
@@ -947,7 +952,7 @@ class ICalendarFile(File):
             elif segments[0].startswith("P="):
                 assert len(segments) == 1
                 try:
-                    yield c[segments[0][2:]]
+                    yield c[segments[0][2:]].to_ical()
                 except KeyError:
                     pass
             else:

--- a/xandikos/store/__init__.py
+++ b/xandikos/store/__init__.py
@@ -58,6 +58,7 @@ PARANOID = False
 
 IndexKey = str
 IndexValue = List[Union[bytes, bool]]
+IndexValueIterator = Iterator[Union[bytes, bool]]
 Indexes = Dict[IndexKey, IndexValue]
 
 
@@ -122,7 +123,7 @@ class File(object):
         else:
             yield "Modified " + item_description
 
-    def _get_index(self, key: IndexKey) -> IndexValue:
+    def _get_index(self, key: IndexKey) -> IndexValueIterator:
         """Obtain an index for this file.
 
         Args:

--- a/xandikos/tests/test_icalendar.py
+++ b/xandikos/tests/test_icalendar.py
@@ -51,6 +51,7 @@ DTSTAMP:20150527T221952Z
 LAST-MODIFIED:20150314T223512Z
 STATUS:NEEDS-ACTION
 SUMMARY:do something
+CATEGORIES:home
 UID:bdc22720-b9e1-42c9-89c2-a85405d8fbff
 END:VTODO
 END:VCALENDAR
@@ -269,6 +270,36 @@ class CalendarFilterTests(unittest.TestCase):
         self.assertTrue(
             filter.check_from_indexes(
                 "file", {"C=VCALENDAR/C=VTODO/P=SUMMARY": [b"do something"]}
+            )
+        )
+        self.assertTrue(filter.check("file", self.cal))
+
+    def test_prop_text_match_category(self):
+        filter = CalendarFilter(None)
+        f = filter.filter_subcomponent("VCALENDAR")
+        f = f.filter_subcomponent("VTODO")
+        f = f.filter_property("CATEGORIES")
+        f.filter_text_match("work")
+        self.assertEqual(
+            self.cal.get_indexes(["C=VCALENDAR/C=VTODO/P=CATEGORIES"]),
+            {"C=VCALENDAR/C=VTODO/P=CATEGORIES": [b'home']},
+        )
+
+        self.assertEqual(
+            filter.index_keys(), [["C=VCALENDAR/C=VTODO/P=CATEGORIES"]])
+        self.assertFalse(
+            filter.check_from_indexes(
+                "file", {"C=VCALENDAR/C=VTODO/P=CATEGORIES": [b"home"]}
+            )
+        )
+        self.assertFalse(filter.check("file", self.cal))
+        filter = CalendarFilter(None)
+        filter.filter_subcomponent("VCALENDAR").filter_subcomponent(
+            "VTODO"
+        ).filter_property("CATEGORIES").filter_text_match("home")
+        self.assertTrue(
+            filter.check_from_indexes(
+                "file", {"C=VCALENDAR/C=VTODO/P=CATEGORIES": [b"home"]}
             )
         )
         self.assertTrue(filter.check("file", self.cal))

--- a/xandikos/tests/test_icalendar.py
+++ b/xandikos/tests/test_icalendar.py
@@ -405,28 +405,40 @@ class TextMatchTest(unittest.TestCase):
         self.assertTrue(tm.match(vText("FOOBAR")))
         self.assertTrue(tm.match(vText("foobar")))
         self.assertFalse(tm.match(vText("fobar")))
+        self.assertTrue(tm.match_indexes({None: [b'foobar']}))
+        self.assertTrue(tm.match_indexes({None: [b'FOOBAR']}))
+        self.assertFalse(tm.match_indexes({None: [b'fobar']}))
 
     def test_casecmp_collation(self):
         tm = TextMatcher("summary", "foobar", collation="i;ascii-casemap")
         self.assertTrue(tm.match(vText("FOOBAR")))
         self.assertTrue(tm.match(vText("foobar")))
         self.assertFalse(tm.match(vText("fobar")))
+        self.assertTrue(tm.match_indexes({None: [b'foobar']}))
+        self.assertTrue(tm.match_indexes({None: [b'FOOBAR']}))
+        self.assertFalse(tm.match_indexes({None: [b'fobar']}))
 
     def test_cmp_collation(self):
         tm = TextMatcher("summary", "foobar", collation="i;octet")
         self.assertFalse(tm.match(vText("FOOBAR")))
         self.assertTrue(tm.match(vText("foobar")))
         self.assertFalse(tm.match(vText("fobar")))
+        self.assertFalse(tm.match_indexes({None: [b'FOOBAR']}))
+        self.assertTrue(tm.match_indexes({None: [b'foobar']}))
+        self.assertFalse(tm.match_indexes({None: [b'fobar']}))
 
     def test_category(self):
-        tm = TextMatcher("summary", "foobar")
+        tm = TextMatcher("categories", "foobar")
         self.assertTrue(tm.match(vCategory(["FOOBAR", "blah"])))
         self.assertTrue(tm.match(vCategory(["foobar"])))
         self.assertFalse(tm.match(vCategory(["fobar"])))
+        self.assertTrue(tm.match_indexes({None: [b'foobar,blah']}))
+        self.assertFalse(tm.match_indexes({None: [b'foobarblah']}))
 
     def test_unknown_type(self):
-        tm = TextMatcher("summary", "foobar")
+        tm = TextMatcher("dontknow", "foobar")
         self.assertFalse(tm.match(object()))
+        self.assertFalse(tm.match_indexes({None: [b'foobarblah']}))
 
     def test_unknown_collation(self):
         self.assertRaises(

--- a/xandikos/tests/test_store.py
+++ b/xandikos/tests/test_store.py
@@ -183,8 +183,7 @@ class BaseStoreTest(object):
                 return [[filtertext]]
 
             def check_from_indexes(self, name, index_values):
-                return any(
-                    self.text in v.encode() for v in index_values[filtertext])
+                return any(self.text in v for v in index_values[filtertext])
 
             def check(self, name, resource):
                 return self.text in b"".join(resource.content)


### PR DESCRIPTION
Be consistent in the way indexes are passed around

Fixes #216

Previously, the first time indexes were generated they were passed around
deserialized (since they were just extracted from the calendar object).

Instead, always serialize them, regardless of whether they were just created
from the calender object or loaded from disk.

Thanks to @tobixen for much of the debugging that led to this change.