### PR TITLE
Updated Makefile to use Python isort module.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ check:
 
 style:
 	$(PYTHON) -m flake8
-	isort --check .
+	$(PYTHON) -m isort --check .
 
 typing:
 	$(PYTHON) -m mypy xandikos


### PR DESCRIPTION
For #266 - I've made `make style` call the isort Python module rather than the executable.