### PR TITLE
Fix _get_resources_by_hrefs: href may be None

### DIFF
--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -1214,7 +1214,7 @@ async def traverse_resource(
             raise AssertionError(f"invalid depth {depth!r}")
         if COLLECTION_RESOURCE_TYPE in resource.resource_types:
             for child_name, child_resource in members_fn(resource):
-                child_href = urllib.parse.urljoin(href, child_name)
+                child_href = ensure_trailing_slash(href) + child_name
                 todo.append((child_href, child_resource, nextdepth))
 
 
@@ -1485,7 +1485,7 @@ def _get_resources_by_hrefs(backend, environ, hrefs):
     script_name = environ["SCRIPT_NAME"]
     # TODO(jelmer): Bulk query hrefs in a more efficient manner
     for href in hrefs:
-        if not href.startswith(script_name):
+        if not href or not href.startswith(script_name):
             resource = None
         else:
             path = href[len(script_name) :]


### PR DESCRIPTION
href may be [`None`](https://github.com/jelmer/xandikos/blob/1cac0717ef6b2b2003e63dd6c6dd6c44bf784a38/xandikos/webdav.py#L1279) for which this function (`_get_resources_by_hrefs`) raises an error.

I observed the error using merkuro/akonadi.