### PR TITLE
Use correct port in kubernetes to not conflict with the metrics port

### DIFF
--- a/examples/xandikos.k8s.yaml
+++ b/examples/xandikos.k8s.yaml
@@ -66,7 +66,7 @@ metadata:
     app: xandikos
 spec:
   ports:
-    - port: 8081
+    - port: 8080
       name: web
   selector:
     app: xandikos

--- a/examples/xandikos.k8s.yaml
+++ b/examples/xandikos.k8s.yaml
@@ -26,7 +26,7 @@ spec:
           - "python3"
           - "-m"
           - "xandikos.web"
-          - "--port=8081"
+          - "--port=8080"
           - "-d/data"
           - "--defaults"
           - "--listen-address=0.0.0.0"


### PR DESCRIPTION
Hi port 8081 is the default port of metrics, and it seems to fail with "address already in use" if the `--port=8081` argument is used, since the metrics server already seems to be running. Changing this to 8080 (the default value) makes it work.