### PR TITLE
Bumping python versions in GitHub workflows and pyproject.toml

### DIFF
--- a/.github/workflows/litmus.yml
+++ b/.github/workflows/litmus.yml
@@ -1,8 +1,8 @@
 name: Litmus DAV compliance tests
 
 on:
-  - push
-  - pull_request
+- push
+- pull_request
 
 jobs:
   litmus:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", '3.9', '3.13']
       fail-fast: false
 
     steps:

--- a/.github/workflows/pycaldav.yml
+++ b/.github/workflows/pycaldav.yml
@@ -1,9 +1,8 @@
----
 name: pycaldav cross-tests
 
 "on":
-  - push
-  - pull_request
+- push
+- pull_request
 
 jobs:
   pycaldav:
@@ -12,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", '3.9']
       fail-fast: false
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,8 +1,8 @@
 name: Python package
 
 on:
-  - push
-  - pull_request
+- push
+- pull_request
 
 jobs:
   pythontests:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", '3.13']
       fail-fast: false
 
     steps:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.x']
+        python-version: ['3.x', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -36,16 +36,16 @@ jobs:
   pypi-publish:
     runs-on: ubuntu-latest
     needs:
-      - release-build
+    - release-build
     permissions:
       id-token: write
 
     steps:
-      - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
+    - name: Retrieve release distributions
+      uses: actions/download-artifact@v4
+      with:
+        name: release-dists
+        path: dist/
 
-      - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+    - name: Publish release distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Operating System :: POSIX",


### PR DESCRIPTION
Bumping python versions in GitHub workflows and pyproject.toml

* Updated the python-version in .github/workflows/pycaldav.yml
* Updated the python-version in .github/workflows/disperse.yml
* Updated the python-version in .github/workflows/pythonpackage.yml
* Updated the python-version in .github/workflows/litmus.yml
* Updated the python-version in .github/workflows/wheels.yaml
* Updated the python-version in .github/workflows/container.yml
* Updated the requires-python field in pyproject.toml to 3.9
