### PR TITLE
Disable autogc for now, since it might cause requests to time out

### DIFF
--- a/xandikos/tests/test_config.py
+++ b/xandikos/tests/test_config.py
@@ -137,4 +137,5 @@ class RepoMetadataTests(TestCase, MetadataTests):
     def setUp(self):
         super().setUp()
         self._repo = dulwich.repo.MemoryRepo()
+        self._repo._autogc_disabled = True
         self._config = RepoCollectionMetadata(self._repo)


### PR DESCRIPTION
This is especially true since most xandikos repositories have never been gced.

Fixes #438