### PR TITLE
Don't return 404 when running CardDAV/CalDAV report when no content type is available

### DIFF
--- a/xandikos/caldav.py
+++ b/xandikos/caldav.py
@@ -332,7 +332,11 @@ class CalendarDataProperty(davcommon.SubbedProperty):
     name = "{%s}calendar-data" % NAMESPACE
 
     def supported_on(self, resource):
-        return resource.get_content_type() == "text/calendar"
+        try:
+            return resource.get_content_type() == "text/calendar"
+        except KeyError:
+            # Resource doesn't have a content type
+            return False
 
     async def get_value_ext(self, base_href, resource, el, environ, requested):
         if len(requested) == 0:

--- a/xandikos/carddav.py
+++ b/xandikos/carddav.py
@@ -65,7 +65,11 @@ class AddressDataProperty(davcommon.SubbedProperty):
     name = "{%s}address-data" % NAMESPACE
 
     def supported_on(self, resource):
-        return resource.get_content_type() == "text/vcard"
+        try:
+            return resource.get_content_type() == "text/vcard"
+        except KeyError:
+            # Resource doesn't have a content type
+            return False
 
     async def get_value_ext(self, href, resource, el, environ, requested):
         # TODO(jelmer): Support subproperties

--- a/xandikos/tests/test_caldav.py
+++ b/xandikos/tests/test_caldav.py
@@ -25,6 +25,7 @@ from icalendar.cal import Calendar as ICalendar
 from xandikos import caldav
 from xandikos.tests import test_webdav
 
+from ..caldav import CalendarDataProperty
 from ..webdav import ET, Property, WebDAVApp
 
 
@@ -375,3 +376,36 @@ END:VEVENT
 END:VCALENDAR
 """,
         )
+
+
+class TestCalendarDataProperty(unittest.TestCase):
+    def test_supported_on_with_calendar(self):
+        """Test that supported_on returns True for calendar resources."""
+        prop = CalendarDataProperty()
+
+        class CalendarResource:
+            def get_content_type(self):
+                return "text/calendar"
+
+        self.assertTrue(prop.supported_on(CalendarResource()))
+
+    def test_supported_on_with_non_calendar(self):
+        """Test that supported_on returns False for non-calendar resources."""
+        prop = CalendarDataProperty()
+
+        class NonCalendarResource:
+            def get_content_type(self):
+                return "text/plain"
+
+        self.assertFalse(prop.supported_on(NonCalendarResource()))
+
+    def test_supported_on_with_missing_content_type(self):
+        """Test that supported_on handles resources without content type gracefully."""
+        prop = CalendarDataProperty()
+
+        class ResourceWithoutContentType:
+            def get_content_type(self):
+                raise KeyError("No content type")
+
+        # This should not raise an exception, but return False
+        self.assertFalse(prop.supported_on(ResourceWithoutContentType()))

--- a/xandikos/tests/test_carddav.py
+++ b/xandikos/tests/test_carddav.py
@@ -20,7 +20,7 @@
 import asyncio
 import unittest
 
-from ..carddav import NAMESPACE, apply_filter
+from ..carddav import NAMESPACE, AddressDataProperty, apply_filter
 from ..vcard import VCardFile
 from ..webdav import ET
 from .test_vcard import EXAMPLE_VCARD1
@@ -44,3 +44,36 @@ class TestApplyFilter(unittest.TestCase):
         tm.text = "Jeffrey"
         loop = asyncio.get_event_loop()
         self.assertTrue(loop.run_until_complete(apply_filter(el, self)))
+
+
+class TestAddressDataProperty(unittest.TestCase):
+    def test_supported_on_with_vcard(self):
+        """Test that supported_on returns True for vcard resources."""
+        prop = AddressDataProperty()
+
+        class VCardResource:
+            def get_content_type(self):
+                return "text/vcard"
+
+        self.assertTrue(prop.supported_on(VCardResource()))
+
+    def test_supported_on_with_non_vcard(self):
+        """Test that supported_on returns False for non-vcard resources."""
+        prop = AddressDataProperty()
+
+        class NonVCardResource:
+            def get_content_type(self):
+                return "text/plain"
+
+        self.assertFalse(prop.supported_on(NonVCardResource()))
+
+    def test_supported_on_with_missing_content_type(self):
+        """Test that supported_on handles resources without content type gracefully."""
+        prop = AddressDataProperty()
+
+        class ResourceWithoutContentType:
+            def get_content_type(self):
+                raise KeyError("No content type")
+
+        # This should not raise an exception, but return False
+        self.assertFalse(prop.supported_on(ResourceWithoutContentType()))


### PR DESCRIPTION
Fixes #247