### PR TITLE
Implement CALDAV:limit-recurrence-set support

### DIFF
--- a/xandikos/caldav.py
+++ b/xandikos/caldav.py
@@ -31,7 +31,12 @@ from icalendar.cal import Component, FreeBusy, component_factory
 from icalendar.prop import vDDDTypes, vPeriod
 
 from . import davcommon, webdav
-from .icalendar import apply_time_range_vevent, as_tz_aware_ts, expand_calendar_rrule
+from .icalendar import (
+    apply_time_range_vevent,
+    as_tz_aware_ts,
+    expand_calendar_rrule,
+    limit_calendar_recurrence_set,
+)
 
 ET = webdav.ET
 
@@ -310,8 +315,8 @@ def extract_from_calendar(incal, requested):
             (start, end) = _parse_time_range(tag)
             incal = expand_calendar_rrule(incal, start, end)
         elif tag.tag == ("{%s}limit-recurrence-set" % NAMESPACE):
-            # TODO(jelmer): https://github.com/jelmer/xandikos/issues/103
-            raise NotImplementedError("limit-recurrence-set is not yet implemented")
+            (start, end) = _parse_time_range(tag)
+            incal = limit_calendar_recurrence_set(incal, start, end)
         elif tag.tag == ("{%s}limit-freebusy-set" % NAMESPACE):
             # TODO(jelmer): https://github.com/jelmer/xandikos/issues/104
             raise NotImplementedError("limit-freebusy-set is not yet implemented")

--- a/xandikos/tests/test_caldav.py
+++ b/xandikos/tests/test_caldav.py
@@ -377,6 +377,76 @@ END:VCALENDAR
 """,
         )
 
+    def test_limit_recurrence_set(self):
+        """Test limit-recurrence-set element."""
+        limit = ET.SubElement(
+            self.requested, "{%s}limit-recurrence-set" % caldav.NAMESPACE
+        )
+        limit.set("start", "20060201T000000Z")
+        limit.set("end", "20060301T000000Z")
+        self.extractEqual(
+            """\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Example Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+DTSTART:20060101T120000Z
+DURATION:PT1H
+RRULE:FREQ=WEEKLY
+DTSTAMP:20060101T120000Z
+SUMMARY:Weekly meeting
+UID:weekly-meeting@example.com
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20060115T140000Z
+DURATION:PT2H
+RECURRENCE-ID:20060115T120000Z
+DTSTAMP:20060101T120000Z
+SUMMARY:Weekly meeting (extended)
+UID:weekly-meeting@example.com
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20060212T120000Z
+DURATION:PT1H
+RECURRENCE-ID:20060212T120000Z
+DTSTAMP:20060101T120000Z
+SUMMARY:Weekly meeting (February)
+UID:weekly-meeting@example.com
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20060312T120000Z
+DURATION:PT1H
+RECURRENCE-ID:20060312T120000Z
+DTSTAMP:20060101T120000Z
+SUMMARY:Weekly meeting (March)
+UID:weekly-meeting@example.com
+END:VEVENT
+END:VCALENDAR
+""",
+            """\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Example Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+DTSTART:20060101T120000Z
+DURATION:PT1H
+RRULE:FREQ=WEEKLY
+DTSTAMP:20060101T120000Z
+SUMMARY:Weekly meeting
+UID:weekly-meeting@example.com
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20060212T120000Z
+DURATION:PT1H
+RECURRENCE-ID:20060212T120000Z
+DTSTAMP:20060101T120000Z
+SUMMARY:Weekly meeting (February)
+UID:weekly-meeting@example.com
+END:VEVENT
+END:VCALENDAR
+""",
+        )
+
 
 class TestCalendarDataProperty(unittest.TestCase):
     def test_supported_on_with_calendar(self):


### PR DESCRIPTION
Add support for the CALDAV:limit-recurrence-set element in CALDAV:calendar-data elements during calendar-query REPORTs. This element limits the set of overridden recurrence instances returned while preserving the master component with its recurrence rules intact.

The implementation:
- Adds limit_calendar_recurrence_set() function to filter recurrence instances
- Properly handles date vs datetime comparisons
- Supports THISANDFUTURE modifications

Fixes #103