### PR TITLE
Store User-Agent header in commit messages

### DIFF
--- a/xandikos/store/__init__.py
+++ b/xandikos/store/__init__.py
@@ -415,6 +415,7 @@ class Store:
         message: Optional[str] = None,
         author: Optional[str] = None,
         replace_etag: Optional[str] = None,
+        requester: Optional[str] = None,
     ) -> tuple[str, str]:
         """Import a single object.
 
@@ -425,6 +426,7 @@ class Store:
           message: Commit message
           author: Optional author
           replace_etag: Etag to replace
+          requester: Optional User-Agent or client information
         Raise:
           NameExists: when the name already exists
           DuplicateUidError: when the uid already exists

--- a/xandikos/store/git.py
+++ b/xandikos/store/git.py
@@ -296,6 +296,7 @@ class GitStore(Store):
         message: Optional[str] = None,
         author: Optional[str] = None,
         replace_etag: Optional[str] = None,
+        requester: Optional[str] = None,
     ) -> tuple[str, str]:
         """Import a single object.
 
@@ -306,6 +307,7 @@ class GitStore(Store):
           message: Commit message
           author: Optional author
           replace_etag: optional etag of object to replace
+          requester: Optional User-Agent or client information
         Raises:
           InvalidETag: when the name already exists but with different etag
           DuplicateUidError: when the uid already exists
@@ -332,6 +334,11 @@ class GitStore(Store):
             except KeyError:
                 old_fi = None
             message = "\n".join(fi.describe_delta(name, old_fi))
+
+        # Add requester information to commit message in RFC822 style
+        if requester is not None:
+            message = message + "\n\nRequester: " + requester
+
         etag = self._import_one(name, fi.normalized(), message, author=author)
         return (name, etag.decode("ascii"))
 

--- a/xandikos/store/vdir.py
+++ b/xandikos/store/vdir.py
@@ -159,6 +159,7 @@ class VdirStore(Store):
         message=None,
         author=None,
         replace_etag=None,
+        requester=None,
     ):
         """Import a single object.
 
@@ -169,6 +170,7 @@ class VdirStore(Store):
           message: Commit message
           author: Optional author
           replace_etag: optional etag of object to replace
+          requester: Optional User-Agent or client information
         Raises:
           InvalidETag: when the name already exists but with different etag
           DuplicateUidError: when the uid already exists

--- a/xandikos/tests/test_webdav.py
+++ b/xandikos/tests/test_webdav.py
@@ -275,7 +275,9 @@ class WebTests(WebTestCase):
         created_items = []
 
         class TestResource(Collection):
-            async def create_member(unused_self, name, contents, content_type):
+            async def create_member(
+                unused_self, name, contents, content_type, requester=None
+            ):
                 created_items.append((name, contents))
                 return (name, '"new-etag"')
 

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -398,10 +398,16 @@ class StoreBasedCollection:
             shutil.rmtree(os.path.join(self.store.path, name))
 
     async def create_member(
-        self, name: str, contents: Iterable[bytes], content_type: str
+        self,
+        name: str,
+        contents: Iterable[bytes],
+        content_type: str,
+        requester: Optional[str] = None,
     ) -> tuple[str, str]:
         try:
-            (name, etag) = self.store.import_one(name, content_type, contents)
+            (name, etag) = self.store.import_one(
+                name, content_type, contents, requester=requester
+            )
         except InvalidFileContents as exc:
             # TODO(jelmer): Not every invalid file is a calendar file..
             raise webdav.PreconditionFailure(


### PR DESCRIPTION
Add support for tracking which client triggered a commit by storing the User-Agent header in git commit messages. This helps with debugging and reverting changes from buggy clients.

Fixes #113