### PR TITLE
Fix index_keys() return type inconsistency causing paranoid mode assertion error

### DIFF
--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -946,11 +946,11 @@ class CalendarFilter(Filter):
                 return False
         return True
 
-    def index_keys(self) -> list[str]:
-        subindexes = []
+    def index_keys(self) -> list[list[str]]:
+        result = []
         for child in self.children:
-            subindexes.extend(child.index_keys())
-        return subindexes
+            result.extend(child.index_keys())
+        return result
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.children!r})"

--- a/xandikos/store/__init__.py
+++ b/xandikos/store/__init__.py
@@ -158,7 +158,7 @@ class Filter:
         """
         raise NotImplementedError(self.check)
 
-    def index_keys(self) -> list[IndexKey]:
+    def index_keys(self) -> list[list[IndexKey]]:
         """Returns a list of indexes that could be used to apply this filter.
 
         Returns: AND-list of OR-options

--- a/xandikos/store/index.py
+++ b/xandikos/store/index.py
@@ -96,7 +96,7 @@ class AutoIndexManager:
         self.indexing_threshold = threshold
 
     def find_present_keys(
-        self, necessary_keys: Iterable[IndexKey]
+        self, necessary_keys: Iterable[Iterable[IndexKey]]
     ) -> Optional[Iterable[IndexKey]]:
         available_keys = self.index.available_keys()
         needed_keys = []

--- a/xandikos/tests/test_vcard.py
+++ b/xandikos/tests/test_vcard.py
@@ -158,7 +158,7 @@ class CardDAVFilterTests(unittest.TestCase):
         )  # Should not be in index keys
 
         keys = filter.index_keys()
-        self.assertEqual(sorted(keys), ["P=EMAIL", "P=FN"])
+        self.assertEqual(sorted(keys), [["P=EMAIL"], ["P=FN"]])
 
     def test_check_from_indexes(self):
         """Test checking from indexes."""

--- a/xandikos/vcard.py
+++ b/xandikos/vcard.py
@@ -328,13 +328,13 @@ class CardDAVFilter(Filter):
 
         return self.test(results) if results else True
 
-    def index_keys(self) -> list[str]:
+    def index_keys(self) -> list[list[str]]:
         """Return the index keys needed for this filter."""
-        keys = []
+        result = []
         for prop_filter in self.property_filters:
             if not prop_filter.is_not_defined:
-                keys.append(f"P={prop_filter.name}")
-        return keys
+                result.append([f"P={prop_filter.name}"])
+        return result
 
 
 def parse_filter(filter_el, cls):


### PR DESCRIPTION
Fixes #235 which occurred when using paranoid mode (double_check_indexes=True) with index_threshold=0.

The bug was caused by CalendarFilter.index_keys() and CardDAVFilter.index_keys() returning list[str] instead of the expected list[list[str]] (AND-list of OR-options). This caused find_present_keys() to iterate over individual characters instead of index key strings, leading to incorrect index key matching and subsequent filter comparison failures.