### PR TITLE
Implement WebDAV MOVE method support

### DIFF
--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -971,6 +971,49 @@ class Collection(Resource):
         """
         raise NotImplementedError(self.create_member)
 
+    async def move_member(
+        self,
+        name: str,
+        destination: "Collection",
+        destination_name: str,
+        overwrite: bool = True,
+    ) -> None:
+        """Move a member from this collection to a different collection.
+
+        This is a default implementation that uses create_member and delete_member.
+        Subclasses may override this for more efficient implementations.
+
+        Args:
+          name: Source member name in this collection
+          destination: Destination collection
+          destination_name: Name in destination collection
+          overwrite: Whether to overwrite if destination exists
+        Raises:
+          KeyError: when the source item doesn't exist
+          FileExistsError: when destination exists and overwrite is False
+        """
+        # Get the source member from this collection
+        source_member = self.get_member(name)
+
+        # Read content from source
+        etag = await source_member.get_etag()
+        body_chunks = await source_member.get_body()
+        body = b"".join(body_chunks)
+        content_type = source_member.get_content_type()
+
+        # Try to create at destination first
+        try:
+            await destination.create_member(destination_name, [body], content_type)
+        except FileExistsError:
+            if not overwrite:
+                raise
+            # Delete existing and retry
+            destination.delete_member(destination_name)
+            await destination.create_member(destination_name, [body], content_type)
+
+        # Delete source from this collection only after successful creation
+        self.delete_member(name, etag)
+
     def get_sync_token(self) -> str:
         """Get sync-token for the current state of this collection."""
         raise NotImplementedError(self.get_sync_token)
@@ -1811,6 +1854,147 @@ class PutMethod(Method):
         return Response(status=201, reason="Created", headers=[("ETag", new_etag)])
 
 
+class MoveMethod(Method):
+    async def handle(self, request, environ, app):
+        # See RFC 4918, section 9.9
+
+        # Get source resource
+        unused_href, source_path, source_resource = app._get_resource_from_environ(
+            request, environ
+        )
+        if source_resource is None:
+            return _send_not_found(request)
+
+        # Get Destination header
+        destination_header = request.headers.get("Destination")
+        if not destination_header:
+            return Response(
+                status=400,
+                reason="Bad Request",
+                body=[b"Destination header required for MOVE"],
+            )
+
+        # Parse destination URL
+        parsed_dest = urllib.parse.urlparse(destination_header)
+
+        # Check if destination is on same server
+        request_host = request.headers.get("Host", "")
+        dest_host = parsed_dest.netloc or request_host
+
+        if dest_host != request_host:
+            return Response(
+                status=502,
+                reason="Bad Gateway",
+                body=[b"Cross-server MOVE not supported"],
+            )
+
+        # Extract destination path
+        dest_path = parsed_dest.path
+        if not dest_path:
+            return Response(
+                status=400, reason="Bad Request", body=[b"Invalid Destination header"]
+            )
+
+        # Remove any script name prefix from destination path
+        script_name = environ.get("SCRIPT_NAME", "")
+        if script_name and dest_path.startswith(script_name):
+            dest_path = dest_path[len(script_name) :]
+
+        # Ensure destination path starts with /
+        if not dest_path.startswith("/"):
+            dest_path = "/" + dest_path
+
+        # Check if source and destination are the same
+        if source_path == dest_path:
+            return Response(
+                status=403,
+                reason="Forbidden",
+                body=[b"Source and destination cannot be the same"],
+            )
+
+        # Check if source is a collection
+        is_collection = COLLECTION_RESOURCE_TYPE in source_resource.resource_types
+
+        # For collections, Depth must be infinity (RFC 4918 9.9.2)
+        if is_collection:
+            depth = request.headers.get("Depth", "infinity")
+            if depth != "infinity":
+                return Response(
+                    status=400,
+                    reason="Bad Request",
+                    body=[b"Depth must be infinity for MOVE on collection"],
+                )
+            # Collections are not supported as members currently
+            return Response(
+                status=501,
+                reason="Not Implemented",
+                body=[b"MOVE for collections not implemented"],
+            )
+
+        # Get parent containers
+        source_container_path, source_name = split_path_preserving_encoding(
+            request, environ
+        )
+        source_container = app.backend.get_resource(source_container_path)
+        if source_container is None:
+            return _send_not_found(request)
+
+        dest_container_path, dest_name = posixpath.split(dest_path.rstrip("/"))
+        if not dest_container_path:
+            dest_container_path = "/"
+        dest_container = app.backend.get_resource(dest_container_path)
+        if dest_container is None:
+            return Response(
+                status=409,
+                reason="Conflict",
+                body=[b"Destination container does not exist"],
+            )
+
+        # Check if destination container is a collection
+        if COLLECTION_RESOURCE_TYPE not in dest_container.resource_types:
+            return Response(
+                status=409,
+                reason="Conflict",
+                body=[b"Destination container is not a collection"],
+            )
+
+        # Handle Overwrite header
+        overwrite_header = request.headers.get("Overwrite", "T")
+        overwrite = overwrite_header.upper() != "F"
+
+        try:
+            # Use the move_member method
+            await source_container.move_member(
+                source_name, dest_container, dest_name, overwrite
+            )
+
+            # If we get here, move succeeded. Return 201 Created
+            # (we can't easily determine if destination existed before)
+            return Response(status=201, reason="Created")
+
+        except KeyError:
+            return _send_not_found(request)
+        except FileExistsError:
+            return Response(
+                status=412,
+                reason="Precondition Failed",
+                body=[b"Destination exists and Overwrite is False"],
+            )
+        except PreconditionFailure as e:
+            return _send_simple_dav_error(
+                request,
+                "412 Precondition Failed",
+                error=ET.Element(e.precondition),
+                description=e.description,
+            )
+        except ResourceLocked:
+            return Response(status=423, reason="Locked")
+        except InsufficientStorage:
+            return Response(status=507, reason="Insufficient Storage")
+        except PermissionError:
+            return Response(status=403, reason="Forbidden")
+
+
 class ReportMethod(Method):
     async def handle(self, request, environ, app):
         # See https://tools.ietf.org/html/rfc3253, section 3.6
@@ -2118,6 +2302,7 @@ class WebDAVApp:
                 DeleteMethod(),
                 PostMethod(),
                 PutMethod(),
+                MoveMethod(),
                 ReportMethod(),
                 PropfindMethod(),
                 ProppatchMethod(),


### PR DESCRIPTION
Add support for the WebDAV MOVE method as specified in RFC 4918 section 9.9.

Collections as members are not supported and return 501 Not Implemented. Cross-server moves are rejected with 502 Bad Gateway.

Fixes #96