### PR TITLE
pycaldav: remove no_expand compatibility

### DIFF
--- a/compat/xandikos-pycaldav.sh
+++ b/compat/xandikos-pycaldav.sh
@@ -41,8 +41,7 @@ only_private = True
 
 caldav_servers = [
     {'url': 'http://localhost:5233/',
-     # no_expand still needed - see https://github.com/jelmer/xandikos/issues/8
-     'incompatibilities': ['no_expand', 'no_scheduling', 'text_search_not_working'],
+     'incompatibilities': ['no_scheduling', 'text_search_not_working'],
     }
 ]
 EOF


### PR DESCRIPTION
Xandikos now handles this properly

cc @tobixen 