### PR TITLE
Implement calendar-description property modification

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -61,6 +61,11 @@ class CalendarCollectionTests(unittest.TestCase):
         self.store.set_description("foo")
         self.assertEqual("foo", self.cal.get_calendar_description())
 
+    def test_set_description(self):
+        self.cal.set_calendar_description("My Calendar")
+        self.assertEqual("My Calendar", self.cal.get_calendar_description())
+        self.assertEqual("My Calendar", self.store.get_description())
+
     def test_color(self):
         self.assertRaises(KeyError, self.cal.get_calendar_color)
         self.cal.set_calendar_color("#aabbcc")

--- a/xandikos/caldav.py
+++ b/xandikos/caldav.py
@@ -72,8 +72,21 @@ class Calendar(webdav.Collection):
     resource_types = webdav.Collection.resource_types + [CALENDAR_RESOURCE_TYPE]
 
     def get_calendar_description(self) -> str:
-        """Return the calendar description."""
+        """Return the calendar description.
+
+        This provides the value for the CALDAV:calendar-description property
+        defined in RFC 4791 Section 5.2.1. It's a human-readable description
+        of the calendar collection.
+        """
         raise NotImplementedError(self.get_calendar_description)
+
+    def set_calendar_description(self, description: str) -> None:
+        """Set the calendar description.
+
+        This sets the value for the CALDAV:calendar-description property
+        defined in RFC 4791 Section 5.2.1.
+        """
+        raise NotImplementedError(self.set_calendar_description)
 
     def get_calendar_color(self) -> str:
         """Return the calendar color."""
@@ -285,9 +298,8 @@ class CalendarDescriptionProperty(webdav.Property):
     async def get_value(self, base_href, resource, el, environ):
         el.text = resource.get_calendar_description()
 
-    # TODO(jelmer): allow modification of this property
     async def set_value(self, href, resource, el):
-        raise NotImplementedError
+        resource.set_calendar_description(el.text)
 
 
 def _extract_from_component(incomp: Component, outcomp: Component, requested) -> None:

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -580,6 +580,9 @@ class CalendarCollection(StoreBasedCollection, caldav.Calendar):
     def get_calendar_description(self):
         return self.store.get_description()
 
+    def set_calendar_description(self, description):
+        self.store.set_description(description)
+
     def get_calendar_color(self):
         color = self.store.get_color()
         if not color:


### PR DESCRIPTION
Added support for modifying the CALDAV:calendar-description property via PROPPATCH operations, as defined in RFC 4791 Section 5.2.1.