### PR TITLE
Fix Depth header validation for multiget REPORT operations

### DIFF
--- a/tests/test_davcommon.py
+++ b/tests/test_davcommon.py
@@ -265,8 +265,13 @@ class MultiGetReporterTests(unittest.TestCase):
 
         asyncio.run(run_test())
 
-    def test_report_depth_validation(self):
-        """Test that multiget operations require Depth: 0."""
+    def test_report_accepts_any_depth(self):
+        """Test that base multiget implementation accepts any depth value.
+
+        The base MultiGetReporter class does not validate the Depth header.
+        Subclasses (CalDAV, CardDAV) handle depth validation according to
+        their specific RFC requirements.
+        """
 
         async def run_test():
             # Create minimal test body
@@ -274,37 +279,58 @@ class MultiGetReporterTests(unittest.TestCase):
             href_el = ET.SubElement(body, "{DAV:}href")
             href_el.text = "/test"
 
-            # Test with invalid depth "1"
-            with self.assertRaises(webdav.BadRequestError) as cm:
-                await self.reporter.report(
+            resource = Mock()
+
+            def mock_resources_by_hrefs(hrefs):
+                return [("/test", resource)]
+
+            async def mock_get_properties_with_data(
+                data_prop, href, res, props, environ, requested
+            ):
+                yield webdav.PropStatus("200 OK", None, ET.Element("prop"))
+
+            with patch(
+                "xandikos.davcommon.get_properties_with_data",
+                mock_get_properties_with_data,
+            ):
+                # Test with depth "0" - should work
+                response = await self.reporter.report(
                     environ={},
                     body=body,
-                    resources_by_hrefs=lambda hrefs: [],
+                    resources_by_hrefs=mock_resources_by_hrefs,
+                    properties={},
+                    base_href="/",
+                    resource=Mock(),
+                    depth="0",
+                    strict=True,
+                )
+                self.assertEqual(response.status, 207)
+
+                # Test with depth "1" - should also work (no validation)
+                response = await self.reporter.report(
+                    environ={},
+                    body=body,
+                    resources_by_hrefs=mock_resources_by_hrefs,
                     properties={},
                     base_href="/",
                     resource=Mock(),
                     depth="1",
                     strict=True,
                 )
+                self.assertEqual(response.status, 207)
 
-            self.assertIn("Depth: 0", str(cm.exception))
-            self.assertIn("Depth: 1", str(cm.exception))
-
-            # Test with invalid depth "infinity"
-            with self.assertRaises(webdav.BadRequestError) as cm:
-                await self.reporter.report(
+                # Test with depth "infinity" - should also work (no validation)
+                response = await self.reporter.report(
                     environ={},
                     body=body,
-                    resources_by_hrefs=lambda hrefs: [],
+                    resources_by_hrefs=mock_resources_by_hrefs,
                     properties={},
                     base_href="/",
                     resource=Mock(),
                     depth="infinity",
                     strict=True,
                 )
-
-            self.assertIn("Depth: 0", str(cm.exception))
-            self.assertIn("Depth: infinity", str(cm.exception))
+                self.assertEqual(response.status, 207)
 
         asyncio.run(run_test())
 

--- a/xandikos/caldav.py
+++ b/xandikos/caldav.py
@@ -405,6 +405,17 @@ class CalendarOrderProperty(webdav.Property):
 
 
 class CalendarMultiGetReporter(davcommon.MultiGetReporter):
+    # RFC 4791 Section 7.9 (CalDAV calendar-multiget) specifies:
+    #   "the 'Depth' header MUST be ignored by the server and SHOULD NOT be
+    #   sent by the client."
+    #
+    # Therefore, we do NOT validate the Depth header for CalDAV multiget
+    # operations. The base class implementation handles the request logic,
+    # and any Depth header value is simply ignored as per the RFC.
+    #
+    # Note: Some CalDAV client libraries
+    # send Depth: 1, which is against the RFC's recommendation but should
+    # not cause the request to fail.
     name = "{%s}calendar-multiget" % NAMESPACE
     resource_type = (CALENDAR_RESOURCE_TYPE, SCHEDULE_INBOX_RESOURCE_TYPE)
     data_property = CalendarDataProperty()

--- a/xandikos/davcommon.py
+++ b/xandikos/davcommon.py
@@ -71,13 +71,9 @@ class MultiGetReporter(webdav.Reporter):
         depth,
         strict,
     ):
-        # RFC 4791 Section 7.9 and RFC 6352 Section 8.7 require Depth: 0
-        if depth != "0":
-            raise webdav.BadRequestError(
-                f"{self.name} requires Depth: 0, got Depth: {depth}"
-            )
         # Note: Resource type validation is performed by the REPORT handler
         # via supported_on() before this method is called
+        # Note: Depth header validation is handled by subclasses as needed
         requested = None
         hrefs = []
         for el in body:


### PR DESCRIPTION
RFC 4791 Section 7.9 (CalDAV calendar-multiget) specifies that the Depth header "MUST be ignored by the server", while RFC 6352 Section 8.7 (CardDAV addressbook-multiget) requires clients to send "Depth: 0" but doesn't mandate server rejection of other values. This is an annoying inconsistency. :-/

Rather than always checking Depth=0, only check if strict mode is enabled.