### PR TITLE
Fix console script entrypoint compatibility with setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ typing = [
 ]
 
 [project.scripts]
-xandikos = "xandikos.__main__:main"
+xandikos = "xandikos.__main__:cli_main"
 
 [tool.setuptools]
 include-package-data = false

--- a/xandikos/__main__.py
+++ b/xandikos/__main__.py
@@ -147,5 +147,10 @@ async def main(argv):
         return 1
 
 
-if __name__ == "__main__":
+def cli_main():
+    """Entry point for the command-line interface (for setuptools console_scripts)."""
     sys.exit(asyncio.run(main(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    cli_main()


### PR DESCRIPTION
The async main() function with required argv parameter is not compatible with setuptools-generated console script entrypoints. Add a sync cli_main() wrapper that handles getting sys.argv and running the async function.

Fixes #560