### PR TITLE
Allow escaped newlines in calendar text fields

### DIFF
--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -147,6 +147,26 @@ class ExtractCalendarUIDTests(unittest.TestCase):
             list(validate_calendar(fi.calendar, strict=False)),
         )
 
+    def test_escaped_newlines_allowed(self):
+        # Test that properly escaped \n and \r sequences are allowed
+        # This is critical for calendar invites from email clients like Thunderbird
+        cal_data = b"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:test-multiline@example.com
+DTSTART:20250101T120000Z
+SUMMARY:Event with description
+DESCRIPTION:Line 1\\nLine 2\\r\\nLine 3
+END:VEVENT
+END:VCALENDAR
+"""
+        fi = ICalendarFile([cal_data], "text/calendar")
+        # Should validate successfully (no exception raised)
+        fi.validate()
+        # Should have no validation errors
+        self.assertEqual([], list(validate_calendar(fi.calendar, strict=False)))
+
 
 class CalendarFilterTests(unittest.TestCase):
     def setUp(self):

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -69,20 +69,18 @@ MAX_RECURRENCE_INSTANCES = 3000
 
 
 # Based on RFC5545 section 3.3.11, CONTROL = %x00-08 / %x0A-1F / %x7F
-# All control characters except HTAB (\x09) are forbidden
-_INVALID_CONTROL_CHARACTERS = (
-    [
-        chr(i)
-        for i in range(0x00, 0x09)  # \x00-\x08
-    ]
-    + [
-        chr(i)
-        for i in range(0x0A, 0x20)  # \x0A-\x1F
-    ]
-    + [
-        chr(0x7F)  # DEL character
-    ]
-)
+# Control characters are forbidden in TEXT values, EXCEPT:
+# - HTAB (\x09) is explicitly allowed
+# - LF (\x0A) and CR (\x0D) are allowed because they appear in the parsed
+#   representation when the icalendar library unescapes valid \n and \r
+#   escape sequences from the iCalendar file (RFC 5545 allows these escapes)
+_INVALID_CONTROL_CHARACTERS = [
+    chr(i)
+    for i in range(0x00, 0x20)  # \x00-\x1F
+    if i not in (0x09, 0x0A, 0x0D)  # Allow HTAB, LF, CR
+] + [
+    chr(0x7F)  # DEL character
+]
 
 
 class MissingProperty(Exception):


### PR DESCRIPTION
The icalendar library unescapes valid \n and \r escape sequences from iCalendar files when parsing, converting them to actual LF and CR characters in Python strings. The validation was incorrectly rejecting these unescaped characters, breaking calendar invites from email clients like Thunderbird.

RFC 5545 section 3.3.11 permits \n and \r escape sequences in TEXT values, which the library correctly parses. The validation now allows LF and CR characters in the parsed representation, while still rejecting other forbidden control characters.

Based on https://github.com/jelmer/xandikos/pull/564
