### PR TITLE
Add test for Evolution RRULE compatibility (issue #80)

### DIFF
--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -1694,7 +1694,7 @@ def _normalize_rrule_until(rrule_str: str, dtstart: date | datetime) -> str:
         parsed["UNTIL"] = [until_dt]
         return parsed.to_ical().decode("utf-8")
 
-    # If UNTIL is a naive datetime, make it UTC
+    # If UNTIL is a naive datetime, make it UTC (issue #80, #571)
     if isinstance(until, datetime) and until.tzinfo is None:
         parsed["UNTIL"] = [until.replace(tzinfo=timezone.utc)]
         return parsed.to_ical().decode("utf-8")


### PR DESCRIPTION
The existing _normalize_rrule_until function already handles Evolution's non-UTC UNTIL values, but there was no explicit test coverage for this case. This adds a test that reproduces the Evolution bug where RRULE UNTIL is sent in local time when DTSTART is timezone-aware.

Refs #80