### PR TITLE
Pluggable storage backend architecture.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,16 @@
+0.4.0	UNRELEASED
+
+ * Add pluggable storage backend system with backend registry, --backend
+   CLI flag, and XANDIKOS_BACKEND environment variable. Built-in backends:
+   git (default), vdir, memory, sql. Third-party backends can be loaded
+   via fully-qualified Python class paths.
+
+ * Add SQL storage backend using SQLAlchemy, supporting SQLite, PostgreSQL,
+   and other databases. Configured via XANDIKOS_SQL_URL environment variable.
+
+ * The -d/--directory flag is now optional for non-filesystem backends
+   (sql, memory).
+
 0.3.4	2026-01-24
 
  * Add --socket-mode and --socket-group flags to set Unix domain socket

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -23,6 +23,7 @@ import shutil
 import stat
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
 
@@ -39,6 +40,7 @@ from xandikos.store import (
 )
 
 from xandikos.icalendar import ICalendarFile, CalendarFilter
+from xandikos.vcard import VCardFile
 from xandikos.store.git import BareGitStore, GitStore, TreeGitStore
 from xandikos.store.memory import MemoryStore
 from xandikos.store.vdir import VdirStore
@@ -586,6 +588,321 @@ class SQLStoreTest(BaseStoreTest, unittest.TestCase):
         store = self.kls.create(store_path)
         store.load_extra_file_handler(ICalendarFile)
         return store
+
+
+class SQLStoreStructuredFieldsTest(unittest.TestCase):
+    """Tests for denormalized dtstart/dtend/summary columns in the SQL backend."""
+
+    def _make_store(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d)
+        store_path = os.path.join(d, "store")
+        db_url = f"sqlite:///{os.path.join(d, 'test.db')}"
+        os.environ["XANDIKOS_SQL_URL"] = db_url
+        self.addCleanup(os.environ.pop, "XANDIKOS_SQL_URL", None)
+        # Clear cached session factories so each test gets a fresh DB
+        from xandikos.store.sql import _session_factories, _engines
+        _session_factories.pop(db_url, None)
+        _engines.pop(db_url, None)
+        store = SQLStore.create(store_path)
+        store.load_extra_file_handler(ICalendarFile)
+        return store, db_url
+
+    def _query_item(self, db_url, name):
+        from xandikos.store.sql import _get_session_factory, Item, select as _sel
+        session_factory = _get_session_factory(db_url)
+        with session_factory() as session:
+            item = session.execute(
+                _sel(Item).where(Item.name == name)
+            ).scalar_one()
+            # SQLite returns naive datetimes — re-attach UTC since we always store UTC
+            dtstart = item.dtstart
+            if dtstart is not None and dtstart.tzinfo is None:
+                dtstart = dtstart.replace(tzinfo=timezone.utc)
+            dtend = item.dtend
+            if dtend is not None and dtend.tzinfo is None:
+                dtend = dtend.replace(tzinfo=timezone.utc)
+            recurrence_end = item.recurrence_end
+            if recurrence_end is not None and recurrence_end.tzinfo is None:
+                recurrence_end = recurrence_end.replace(tzinfo=timezone.utc)
+            return {
+                "dtstart": dtstart,
+                "dtend": dtend,
+                "summary": item.summary,
+                "rrule": item.rrule,
+                "recurrence_end": recurrence_end,
+            }
+
+    def test_vevent_with_dtstart_dtend_summary(self):
+        store, db_url = self._make_store()
+        ics = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:ev1@example.com
+DTSTART:20250215T100000Z
+DTEND:20250215T120000Z
+SUMMARY:Team Meeting
+END:VEVENT
+END:VCALENDAR
+"""
+        name, _etag = store.import_one("ev1.ics", "text/calendar", [ics])
+        row = self._query_item(db_url, name)
+        self.assertEqual(row["summary"], "Team Meeting")
+        self.assertEqual(
+            row["dtstart"],
+            datetime(2025, 2, 15, 10, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            row["dtend"],
+            datetime(2025, 2, 15, 12, 0, tzinfo=timezone.utc),
+        )
+
+    def test_vevent_with_duration(self):
+        store, db_url = self._make_store()
+        ics = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:ev2@example.com
+DTSTART:20250301T090000Z
+DURATION:PT1H30M
+SUMMARY:Standup
+END:VEVENT
+END:VCALENDAR
+"""
+        name, _ = store.import_one("ev2.ics", "text/calendar", [ics])
+        row = self._query_item(db_url, name)
+        self.assertEqual(
+            row["dtstart"],
+            datetime(2025, 3, 1, 9, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            row["dtend"],
+            datetime(2025, 3, 1, 10, 30, tzinfo=timezone.utc),
+        )
+
+    def test_allday_event(self):
+        store, db_url = self._make_store()
+        ics = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:ev3@example.com
+DTSTART;VALUE=DATE:20250401
+DTEND;VALUE=DATE:20250402
+SUMMARY:Holiday
+END:VEVENT
+END:VCALENDAR
+"""
+        name, _ = store.import_one("ev3.ics", "text/calendar", [ics])
+        row = self._query_item(db_url, name)
+        self.assertEqual(
+            row["dtstart"],
+            datetime(2025, 4, 1, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            row["dtend"],
+            datetime(2025, 4, 2, 0, 0, tzinfo=timezone.utc),
+        )
+
+    def test_vtodo_with_due(self):
+        store, db_url = self._make_store()
+        ics = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:todo1@example.com
+DTSTART:20250501T080000Z
+DUE:20250501T170000Z
+SUMMARY:Finish report
+END:VTODO
+END:VCALENDAR
+"""
+        name, _ = store.import_one("todo1.ics", "text/calendar", [ics])
+        row = self._query_item(db_url, name)
+        self.assertEqual(row["summary"], "Finish report")
+        self.assertEqual(
+            row["dtend"],
+            datetime(2025, 5, 1, 17, 0, tzinfo=timezone.utc),
+        )
+
+    def test_event_without_summary(self):
+        store, db_url = self._make_store()
+        ics = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:ev4@example.com
+DTSTART:20250601T140000Z
+DTEND:20250601T150000Z
+END:VEVENT
+END:VCALENDAR
+"""
+        name, _ = store.import_one("ev4.ics", "text/calendar", [ics])
+        row = self._query_item(db_url, name)
+        self.assertIsNone(row["summary"])
+        self.assertIsNotNone(row["dtstart"])
+
+    def test_non_calendar_file(self):
+        store, db_url = self._make_store()
+        name, _ = store.import_one("plain.txt", "text/plain", [b"Hello world"])
+        row = self._query_item(db_url, name)
+        self.assertIsNone(row["dtstart"])
+        self.assertIsNone(row["dtend"])
+        self.assertIsNone(row["summary"])
+
+    def test_vtodo_without_dates(self):
+        """VTODO from EXAMPLE_VCALENDAR1 has no DTSTART/DUE but has SUMMARY."""
+        store, db_url = self._make_store()
+        name, _ = store.import_one("todo.ics", "text/calendar", [EXAMPLE_VCALENDAR1])
+        row = self._query_item(db_url, name)
+        self.assertEqual(row["summary"], "do something")
+        self.assertIsNone(row["dtstart"])
+        self.assertIsNone(row["dtend"])
+
+    def test_update_item_refreshes_fields(self):
+        store, db_url = self._make_store()
+        ics_v1 = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:upd@example.com
+DTSTART:20250101T080000Z
+DTEND:20250101T090000Z
+SUMMARY:Original
+END:VEVENT
+END:VCALENDAR
+"""
+        ics_v2 = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:upd@example.com
+DTSTART:20250202T100000Z
+DTEND:20250202T110000Z
+SUMMARY:Updated
+END:VEVENT
+END:VCALENDAR
+"""
+        name, etag1 = store.import_one("upd.ics", "text/calendar", [ics_v1])
+        row1 = self._query_item(db_url, name)
+        self.assertEqual(row1["summary"], "Original")
+
+        name, etag2 = store.import_one("upd.ics", "text/calendar", [ics_v2], replace_etag=etag1)
+        row2 = self._query_item(db_url, name)
+        self.assertEqual(row2["summary"], "Updated")
+        self.assertEqual(
+            row2["dtstart"],
+            datetime(2025, 2, 2, 10, 0, tzinfo=timezone.utc),
+        )
+
+
+    def test_vcard_fn_to_summary(self):
+        """vCard FN should be stored as summary."""
+        store, db_url = self._make_store()
+        store.load_extra_file_handler(VCardFile)
+        vcard = b"""\
+BEGIN:VCARD
+VERSION:3.0
+FN:John Doe
+N:Doe;John;;;
+UID:jdoe@example.com
+END:VCARD
+"""
+        name, _ = store.import_one("jdoe.vcf", "text/vcard", [vcard])
+        row = self._query_item(db_url, name)
+        self.assertEqual(row["summary"], "John Doe")
+        self.assertIsNone(row["dtstart"])
+        self.assertIsNone(row["rrule"])
+
+    def test_rrule_with_until(self):
+        """Recurring event with UNTIL should set rrule and recurrence_end."""
+        store, db_url = self._make_store()
+        ics = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:rec1@example.com
+DTSTART:20250101T090000Z
+DTEND:20250101T100000Z
+RRULE:FREQ=WEEKLY;UNTIL=20250401T090000Z
+SUMMARY:Weekly sync
+END:VEVENT
+END:VCALENDAR
+"""
+        name, _ = store.import_one("rec1.ics", "text/calendar", [ics])
+        row = self._query_item(db_url, name)
+        self.assertEqual(row["summary"], "Weekly sync")
+        self.assertIsNotNone(row["rrule"])
+        self.assertIn("FREQ=WEEKLY", row["rrule"])
+        self.assertEqual(
+            row["recurrence_end"],
+            datetime(2025, 4, 1, 9, 0, tzinfo=timezone.utc),
+        )
+
+    def test_rrule_with_count(self):
+        """Recurring event with COUNT should compute recurrence_end from last occurrence."""
+        store, db_url = self._make_store()
+        # Daily for 5 days starting Jan 10 → last occurrence Jan 14
+        ics = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:rec2@example.com
+DTSTART:20250110T080000Z
+DTEND:20250110T090000Z
+RRULE:FREQ=DAILY;COUNT=5
+SUMMARY:Daily standup
+END:VEVENT
+END:VCALENDAR
+"""
+        name, _ = store.import_one("rec2.ics", "text/calendar", [ics])
+        row = self._query_item(db_url, name)
+        self.assertIn("FREQ=DAILY", row["rrule"])
+        self.assertEqual(
+            row["recurrence_end"],
+            datetime(2025, 1, 14, 8, 0, tzinfo=timezone.utc),
+        )
+
+    def test_rrule_infinite(self):
+        """Recurring event without UNTIL/COUNT should have recurrence_end=None."""
+        store, db_url = self._make_store()
+        ics = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:rec3@example.com
+DTSTART:20250101T120000Z
+DTEND:20250101T130000Z
+RRULE:FREQ=YEARLY
+SUMMARY:Birthday
+END:VEVENT
+END:VCALENDAR
+"""
+        name, _ = store.import_one("rec3.ics", "text/calendar", [ics])
+        row = self._query_item(db_url, name)
+        self.assertIn("FREQ=YEARLY", row["rrule"])
+        self.assertIsNone(row["recurrence_end"])
+
+    def test_non_recurring_event_no_rrule(self):
+        """Non-recurring event should have rrule=None and recurrence_end=None."""
+        store, db_url = self._make_store()
+        ics = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:norec@example.com
+DTSTART:20250301T100000Z
+DTEND:20250301T110000Z
+SUMMARY:One-off meeting
+END:VEVENT
+END:VCALENDAR
+"""
+        name, _ = store.import_one("norec.ics", "text/calendar", [ics])
+        row = self._query_item(db_url, name)
+        self.assertIsNone(row["rrule"])
+        self.assertIsNone(row["recurrence_end"])
 
 
 class RegistryTest(unittest.TestCase):

--- a/xandikos/__main__.py
+++ b/xandikos/__main__.py
@@ -81,6 +81,11 @@ def add_create_collection_parser(parser):
         default=None,
         help="Storage backend to use (default: git).",
     )
+    parser.add_argument(
+        "--sql-url",
+        default=None,
+        help="SQLAlchemy database URL for the SQL backend. Overrides XANDIKOS_SQL_URL.",
+    )
 
 
 async def create_collection_main(args, parser):
@@ -90,6 +95,9 @@ async def create_collection_main(args, parser):
     logger = logging.getLogger(__name__)
 
     backend_name = getattr(args, "backend", None) or os.environ.get("XANDIKOS_BACKEND")
+
+    if getattr(args, "sql_url", None):
+        os.environ["XANDIKOS_SQL_URL"] = args.sql_url
 
     directory = args.directory
     backend = XandikosBackend(directory, backend=backend_name)

--- a/xandikos/__main__.py
+++ b/xandikos/__main__.py
@@ -86,19 +86,12 @@ def add_create_collection_parser(parser):
 async def create_collection_main(args, parser):
     """Main function for the create-collection subcommand."""
     from .web import XandikosBackend
-    from .store.registry import get_backend
 
     logger = logging.getLogger(__name__)
 
     backend_name = getattr(args, "backend", None) or os.environ.get("XANDIKOS_BACKEND")
-    backend_cls = get_backend(backend_name)
 
     directory = args.directory
-    if directory is None and backend_cls.uses_filesystem():
-        parser.error(
-            f"-d/--directory is required for the {backend_name or 'git'!r} backend"
-        )
-
     backend = XandikosBackend(directory, backend=backend_name)
     collection_path = args.name
     collection_type = (

--- a/xandikos/store/__init__.py
+++ b/xandikos/store/__init__.py
@@ -578,16 +578,6 @@ class Store:
         raise NotImplementedError(self.set_source_url)
 
     @classmethod
-    def uses_filesystem(cls) -> bool:
-        """Whether this backend requires a filesystem directory.
-
-        Returns True for filesystem-backed stores (git, vdir).
-        Returns False for stores that manage their own persistence (sql, memory).
-        Used to determine whether the -d/--directory flag is required.
-        """
-        return True
-
-    @classmethod
     def open_from_path(cls, path: str, **kwargs) -> "Store":
         """Open an existing store at a filesystem path.
 

--- a/xandikos/store/__init__.py
+++ b/xandikos/store/__init__.py
@@ -29,6 +29,7 @@ from collections.abc import Iterable, Iterator
 from typing import Optional
 
 from .index import AutoIndexManager, IndexDict, IndexKey, IndexValueIterator
+from .registry import get_backend
 
 logger = getLogger("xandikos")
 
@@ -576,15 +577,74 @@ class Store:
         """Set the source URL."""
         raise NotImplementedError(self.set_source_url)
 
+    @classmethod
+    def uses_filesystem(cls) -> bool:
+        """Whether this backend requires a filesystem directory.
 
-def open_store(location: str) -> Store:
+        Returns True for filesystem-backed stores (git, vdir).
+        Returns False for stores that manage their own persistence (sql, memory).
+        Used to determine whether the -d/--directory flag is required.
+        """
+        return True
+
+    @classmethod
+    def open_from_path(cls, path: str, **kwargs) -> "Store":
+        """Open an existing store at a filesystem path.
+
+        Args:
+          path: Path to the store
+          **kwargs: Backend-specific options
+        Returns: A Store instance
+        Raises: NotStoreError if the path is not a valid store for this backend
+        """
+        raise NotImplementedError(cls.open_from_path)
+
+    @classmethod
+    def create(cls, path: str) -> "Store":
+        """Create a new, empty store at a filesystem path.
+
+        Args:
+          path: Path for the new store
+        Returns: A Store instance
+        """
+        raise NotImplementedError(cls.create)
+
+    @classmethod
+    def has_collections_under(cls, path: str) -> bool:
+        """Check if any collections exist under the given path prefix.
+
+        Used to determine if a path is a collection set (container of stores).
+        Filesystem-based backends return False here and rely on os.path.isdir()
+        in the web layer. Non-filesystem backends should override this.
+
+        Args:
+          path: Path prefix to check
+        Returns: True if collections exist under this path
+        """
+        return False
+
+    @classmethod
+    def list_children_under(cls, path: str) -> list[str]:
+        """List direct child collection names under a path prefix.
+
+        Used by collection set resources to enumerate subcollections.
+        Filesystem-based backends return [] here and rely on os.listdir()
+        in the web layer. Non-filesystem backends should override this.
+
+        Args:
+          path: Path prefix to list children of
+        Returns: List of child names
+        """
+        return []
+
+
+def open_store(location: str, backend: str | None = None) -> Store:
     """Open store from a location string.
 
     Args:
       location: Location string to open
+      backend: Backend name (default: from registry default)
     Returns: A `Store`
     """
-    # For now, just support opening git stores
-    from .git import GitStore
-
-    return GitStore.open_from_path(location)
+    cls = get_backend(backend)
+    return cls.open_from_path(location)

--- a/xandikos/store/git.py
+++ b/xandikos/store/git.py
@@ -445,6 +445,9 @@ class GitStore(Store):
 
         Returns: A `GitStore`
         """
+        # Delegate to TreeGitStore if called on GitStore directly
+        if cls is GitStore:
+            return TreeGitStore.create(path)
         raise NotImplementedError(cls.create)
 
     @classmethod

--- a/xandikos/store/memory.py
+++ b/xandikos/store/memory.py
@@ -223,11 +223,6 @@ class MemoryStore(Store):
         self._source_url = url
 
     @classmethod
-    def uses_filesystem(cls) -> bool:
-        """Memory store does not use the filesystem."""
-        return False
-
-    @classmethod
     def open_from_path(cls, path: str, **kwargs) -> "MemoryStore":
         """Open a memory store (path is ignored)."""
         return cls()

--- a/xandikos/store/memory.py
+++ b/xandikos/store/memory.py
@@ -39,6 +39,7 @@ class MemoryStore(Store):
 
     def __init__(self, *, check_for_duplicate_uids=True):
         super().__init__(MemoryIndex())
+        self.path = None
         self._items = {}  # name -> (content_type, data, etag)
         self._etag_counter = 0
         self._check_for_duplicate_uids = check_for_duplicate_uids
@@ -220,3 +221,18 @@ class MemoryStore(Store):
     def set_source_url(self, url: str) -> None:
         """Set source URL (no-op for memory store)."""
         self._source_url = url
+
+    @classmethod
+    def uses_filesystem(cls) -> bool:
+        """Memory store does not use the filesystem."""
+        return False
+
+    @classmethod
+    def open_from_path(cls, path: str, **kwargs) -> "MemoryStore":
+        """Open a memory store (path is ignored)."""
+        return cls()
+
+    @classmethod
+    def create(cls, path: str) -> "MemoryStore":
+        """Create a new memory store (path is ignored)."""
+        return cls()

--- a/xandikos/store/registry.py
+++ b/xandikos/store/registry.py
@@ -1,0 +1,93 @@
+# Xandikos
+# Copyright (C) 2016-2017 Jelmer Vernooĳ <jelmer@jelmer.uk>, et al.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 3
+# of the License or (at your option) any later version of
+# the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301, USA.
+
+"""Backend registry for pluggable store implementations.
+
+Each backend class must provide:
+  - open_from_path(path, **kwargs) -> Store  (classmethod)
+  - create(path) -> Store  (classmethod)
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import Store
+
+_BACKENDS: dict[str, type[Store]] = {}
+
+DEFAULT_BACKEND = "git"
+
+_builtins_registered = False
+
+
+def register_backend(name: str, cls: type[Store]) -> None:
+    """Register a backend class under a short name."""
+    _BACKENDS[name] = cls
+
+
+def _register_builtins() -> None:
+    """Lazily register built-in backends on first use."""
+    global _builtins_registered
+    if _builtins_registered:
+        return
+    _builtins_registered = True
+    from .git import GitStore
+    from .vdir import VdirStore
+    from .memory import MemoryStore
+
+    register_backend("git", GitStore)
+    register_backend("vdir", VdirStore)
+    register_backend("memory", MemoryStore)
+
+    try:
+        from .sql import SQLStore
+
+        register_backend("sql", SQLStore)
+    except ImportError:
+        pass  # sqlalchemy not installed
+
+
+def get_backend(name: str | None = None) -> type[Store]:
+    """Resolve a backend name to its class.
+
+    Args:
+      name: Short name ('git', 'vdir', 'memory', 'sql'), a fully-qualified
+            Python class path ('mypackage.MyStore'), or None for default.
+    Returns: The backend class.
+    Raises: ValueError if the backend cannot be resolved.
+    """
+    if name is None:
+        name = DEFAULT_BACKEND
+    _register_builtins()
+    if name in _BACKENDS:
+        return _BACKENDS[name]
+    # Try dotted import path: 'package.module.ClassName'
+    if "." in name:
+        module_path, _, class_name = name.rpartition(".")
+        try:
+            module = importlib.import_module(module_path)
+            return getattr(module, class_name)
+        except (ImportError, AttributeError) as exc:
+            raise ValueError(f"Cannot import backend {name!r}: {exc}") from exc
+    raise ValueError(
+        f"Unknown backend {name!r}. Available: {', '.join(sorted(_BACKENDS.keys()))}"
+    )

--- a/xandikos/store/sql.py
+++ b/xandikos/store/sql.py
@@ -1,0 +1,512 @@
+# Xandikos
+# Copyright (C) 2016-2017 Jelmer Vernooĳ <jelmer@jelmer.uk>, et al.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 3
+# of the License or (at your option) any later version of
+# the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301, USA.
+
+"""SQL store backend using SQLAlchemy.
+
+Provides a CalDAV/CardDAV storage backend backed by a relational database.
+Supports any database supported by SQLAlchemy (SQLite, PostgreSQL, MySQL, etc.).
+
+Usage:
+    XANDIKOS_BACKEND=sql XANDIKOS_SQL_URL=sqlite:///xandikos.db xandikos serve
+
+    Or with PostgreSQL:
+    XANDIKOS_BACKEND=sql XANDIKOS_SQL_URL=postgresql://user:pass@localhost/xandikos xandikos serve
+"""
+
+import hashlib
+import os
+import uuid
+from collections.abc import Iterable, Iterator
+from datetime import datetime, timezone
+from logging import getLogger
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    LargeBinary,
+    String,
+    Text,
+    UniqueConstraint,
+    create_engine,
+    event,
+    select,
+)
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    Session,
+    mapped_column,
+    relationship,
+    sessionmaker,
+)
+
+from . import (
+    MIMETYPES,
+    VALID_STORE_TYPES,
+    DuplicateUidError,
+    InvalidETag,
+    NoSuchItem,
+    NotStoreError,
+    Store,
+    open_by_content_type,
+    open_by_extension,
+)
+from .index import MemoryIndex
+
+logger = getLogger("xandikos")
+
+# ---------------------------------------------------------------------------
+# ORM Model
+# ---------------------------------------------------------------------------
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Collection(Base):
+    """A CalDAV/CardDAV collection (calendar or address book)."""
+
+    __tablename__ = "collections"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    path: Mapped[str] = mapped_column(String(2048), unique=True, nullable=False)
+    store_type: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )  # calendar, addressbook, etc.
+    displayname: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    color: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    comment: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    order: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    refreshrate: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    timezone: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    items: Mapped[list["Item"]] = relationship(
+        "Item", back_populates="collection", cascade="all, delete-orphan"
+    )
+
+    def __repr__(self) -> str:
+        return f"<Collection(path={self.path!r}, type={self.store_type!r})>"
+
+
+class Item(Base):
+    """A single CalDAV/CardDAV resource (e.g. a VEVENT or VCARD)."""
+
+    __tablename__ = "items"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    collection_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("collections.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(
+        String(512), nullable=False
+    )  # filename (e.g. "event.ics")
+    uid: Mapped[str | None] = mapped_column(
+        String(512), nullable=True
+    )  # iCalendar/vCard UID
+    content_type: Mapped[str] = mapped_column(String(128), nullable=False)  # MIME type
+    data: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)  # raw file content
+    etag: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    collection: Mapped["Collection"] = relationship(
+        "Collection", back_populates="items"
+    )
+
+    __table_args__ = (
+        UniqueConstraint("collection_id", "name", name="uq_collection_item_name"),
+        Index("ix_collection_uid", "collection_id", "uid"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Item(name={self.name!r}, uid={self.uid!r}, etag={self.etag!r})>"
+
+
+# ---------------------------------------------------------------------------
+# Helper: session management
+# ---------------------------------------------------------------------------
+
+_engines: dict[str, object] = {}
+_session_factories: dict[str, sessionmaker] = {}
+
+
+def _get_session_factory(db_url: str) -> sessionmaker:
+    """Get or create a session factory for the given database URL."""
+    if db_url not in _session_factories:
+        engine = create_engine(db_url)
+        # Enable WAL mode for SQLite for better concurrent access
+        if db_url.startswith("sqlite"):
+
+            @event.listens_for(engine, "connect")
+            def set_sqlite_pragma(dbapi_conn, connection_record):
+                cursor = dbapi_conn.cursor()
+                cursor.execute("PRAGMA journal_mode=WAL")
+                cursor.execute("PRAGMA foreign_keys=ON")
+                cursor.close()
+
+        Base.metadata.create_all(engine)
+        _engines[db_url] = engine
+        _session_factories[db_url] = sessionmaker(bind=engine)
+    return _session_factories[db_url]
+
+
+def _compute_etag(data: bytes) -> str:
+    """Compute an ETag from content bytes."""
+    return hashlib.sha256(data).hexdigest()[:40]
+
+
+# ---------------------------------------------------------------------------
+# SQLStore
+# ---------------------------------------------------------------------------
+
+
+class SQLStore(Store):
+    """A Store backed by a SQL database via SQLAlchemy."""
+
+    def __init__(
+        self,
+        db_url: str,
+        collection_path: str,
+        *,
+        check_for_duplicate_uids: bool = True,
+        **kwargs,
+    ) -> None:
+        super().__init__(MemoryIndex(), **kwargs)
+        self._db_url = db_url
+        self._collection_path = collection_path
+        self._check_for_duplicate_uids = check_for_duplicate_uids
+        self._session_factory = _get_session_factory(db_url)
+
+    @property
+    def path(self) -> str:
+        return self._collection_path
+
+    def _session(self) -> Session:
+        return self._session_factory()
+
+    def _get_collection(self, session: Session) -> Collection | None:
+        return session.execute(
+            select(Collection).where(Collection.path == self._collection_path)
+        ).scalar_one_or_none()
+
+    def _require_collection(self, session: Session) -> Collection:
+        col = self._get_collection(session)
+        if col is None:
+            raise NotStoreError(self._collection_path)
+        return col
+
+    # -- Factory classmethods --
+
+    @classmethod
+    def uses_filesystem(cls) -> bool:
+        """SQL store does not use the filesystem."""
+        return False
+
+    @classmethod
+    def _get_db_url(cls) -> str:
+        url = os.environ.get("XANDIKOS_SQL_URL")
+        if url is None:
+            raise ValueError(
+                "XANDIKOS_SQL_URL environment variable must be set for the SQL backend"
+            )
+        return url
+
+    @classmethod
+    def open_from_path(cls, path: str, **kwargs) -> "SQLStore":
+        db_url = cls._get_db_url()
+        session_factory = _get_session_factory(db_url)
+        with session_factory() as session:
+            col = session.execute(
+                select(Collection).where(Collection.path == path)
+            ).scalar_one_or_none()
+            if col is None:
+                raise NotStoreError(path)
+        return cls(db_url, path, **kwargs)
+
+    @classmethod
+    def create(cls, path: str) -> "SQLStore":
+        db_url = cls._get_db_url()
+        session_factory = _get_session_factory(db_url)
+        with session_factory() as session:
+            existing = session.execute(
+                select(Collection).where(Collection.path == path)
+            ).scalar_one_or_none()
+            if existing is not None:
+                raise FileExistsError(path)
+            col = Collection(path=path)
+            session.add(col)
+            session.commit()
+        return cls(db_url, path)
+
+    # -- Core read/write operations --
+
+    def iter_with_etag(self, ctag: str | None = None) -> Iterator[tuple[str, str, str]]:
+        with self._session() as session:
+            col = self._get_collection(session)
+            if col is None:
+                return
+            for item in col.items:
+                yield (item.name, item.content_type, item.etag)
+
+    def _get_raw(self, name: str, etag: str | None = None) -> Iterable[bytes]:
+        with self._session() as session:
+            col = self._require_collection(session)
+            item = session.execute(
+                select(Item).where(Item.collection_id == col.id, Item.name == name)
+            ).scalar_one_or_none()
+            if item is None:
+                raise KeyError(name)
+            if etag is not None and item.etag != etag:
+                raise KeyError(name)
+            return [item.data]
+
+    def import_one(
+        self,
+        name: str,
+        content_type: str,
+        data: Iterable[bytes],
+        message: str | None = None,
+        author: str | None = None,
+        replace_etag: str | None = None,
+        requester: str | None = None,
+    ) -> tuple[str, str]:
+        if content_type is None:
+            fi = open_by_extension(data, name, self.extra_file_handlers)
+        else:
+            fi = open_by_content_type(data, content_type, self.extra_file_handlers)
+
+        if name is None:
+            name = str(uuid.uuid4())
+            extension = MIMETYPES.guess_extension(content_type)
+            if extension is not None:
+                name += extension
+
+        fi.validate()
+
+        try:
+            uid = fi.get_uid()
+        except (KeyError, NotImplementedError):
+            uid = None
+
+        normalized_data = b"".join(fi.normalized())
+        new_etag = _compute_etag(normalized_data)
+
+        with self._session() as session:
+            col = self._require_collection(session)
+
+            # Check for duplicate UID
+            if uid is not None and self._check_for_duplicate_uids:
+                existing = session.execute(
+                    select(Item).where(
+                        Item.collection_id == col.id,
+                        Item.uid == uid,
+                        Item.name != name,
+                    )
+                ).scalar_one_or_none()
+                if existing is not None:
+                    raise DuplicateUidError(uid, existing.name, name)
+
+            # Check existing item
+            item = session.execute(
+                select(Item).where(Item.collection_id == col.id, Item.name == name)
+            ).scalar_one_or_none()
+
+            if item is not None:
+                if replace_etag is not None and item.etag != replace_etag:
+                    raise InvalidETag(name, replace_etag, item.etag)
+                item.data = normalized_data
+                item.etag = new_etag
+                item.content_type = content_type
+                item.uid = uid
+            else:
+                if replace_etag is not None:
+                    raise InvalidETag(name, replace_etag, "(no existing item)")
+                item = Item(
+                    collection_id=col.id,
+                    name=name,
+                    uid=uid,
+                    content_type=content_type,
+                    data=normalized_data,
+                    etag=new_etag,
+                )
+                session.add(item)
+
+            session.commit()
+
+        return (name, new_etag)
+
+    def delete_one(
+        self,
+        name: str,
+        message: str | None = None,
+        author: str | None = None,
+        etag: str | None = None,
+    ) -> None:
+        with self._session() as session:
+            col = self._require_collection(session)
+            item = session.execute(
+                select(Item).where(Item.collection_id == col.id, Item.name == name)
+            ).scalar_one_or_none()
+            if item is None:
+                raise NoSuchItem(name)
+            if etag is not None and item.etag != etag:
+                raise InvalidETag(name, etag, item.etag)
+            session.delete(item)
+            session.commit()
+
+    def get_ctag(self) -> str:
+        with self._session() as session:
+            col = self._require_collection(session)
+            # ctag = hash of all (name, etag) pairs, deterministic
+            parts = sorted(f"{item.name}:{item.etag}" for item in col.items)
+            return hashlib.sha256("|".join(parts).encode()).hexdigest()[:40]
+
+    def iter_changes(
+        self, old_ctag: str, new_ctag: str
+    ) -> Iterator[tuple[str, str, str, str]]:
+        # SQL store doesn't track historical state per-ctag.
+        # Return empty — sync-collection will fall back to full listing.
+        return iter([])
+
+    # -- Metadata operations --
+
+    def _get_meta(self, attr: str) -> str:
+        with self._session() as session:
+            col = self._require_collection(session)
+            val = getattr(col, attr)
+            if val is None:
+                raise KeyError(attr)
+            return val
+
+    def _set_meta(self, attr: str, value: str | None) -> None:
+        with self._session() as session:
+            col = self._require_collection(session)
+            setattr(col, attr, value)
+            session.commit()
+
+    def get_description(self) -> str:
+        return self._get_meta("description")
+
+    def set_description(self, description: str) -> None:
+        self._set_meta("description", description)
+
+    def get_displayname(self) -> str:
+        return self._get_meta("displayname")
+
+    def set_displayname(self, displayname: str) -> None:
+        self._set_meta("displayname", displayname)
+
+    def get_color(self) -> str:
+        return self._get_meta("color")
+
+    def set_color(self, color: str) -> None:
+        self._set_meta("color", color)
+
+    def get_comment(self) -> str:
+        return self._get_meta("comment")
+
+    def set_comment(self, comment: str) -> None:
+        self._set_meta("comment", comment)
+
+    def set_type(self, store_type: str) -> None:
+        if store_type not in VALID_STORE_TYPES:
+            raise ValueError(f"Invalid store type: {store_type}")
+        self._set_meta("store_type", store_type)
+
+    def get_type(self) -> str:
+        try:
+            return self._get_meta("store_type")
+        except KeyError:
+            return super().get_type()
+
+    def get_source_url(self) -> str:
+        return self._get_meta("source_url")
+
+    def set_source_url(self, url: str) -> None:
+        self._set_meta("source_url", url)
+
+    def destroy(self) -> None:
+        with self._session() as session:
+            col = self._get_collection(session)
+            if col is not None:
+                session.delete(col)
+                session.commit()
+
+    def subdirectories(self) -> Iterator[str]:
+        # SQL store doesn't have filesystem subdirectories
+        return iter([])
+
+    @classmethod
+    def has_collections_under(cls, path: str) -> bool:
+        """Check if any SQL collections exist under the given path prefix."""
+        try:
+            db_url = cls._get_db_url()
+        except ValueError:
+            return False
+        session_factory = _get_session_factory(db_url)
+        prefix = path.rstrip("/") + "/"
+        with session_factory() as session:
+            return (
+                session.execute(
+                    select(Collection.id).where(Collection.path.like(prefix + "%"))
+                ).first()
+                is not None
+            )
+
+    @classmethod
+    def list_children_under(cls, path: str) -> list[str]:
+        """List direct child collection names under a path prefix."""
+        try:
+            db_url = cls._get_db_url()
+        except ValueError:
+            return []
+        session_factory = _get_session_factory(db_url)
+        prefix = path.rstrip("/") + "/"
+        with session_factory() as session:
+            cols = session.execute(
+                select(Collection.path).where(Collection.path.like(prefix + "%"))
+            ).all()
+            children = set()
+            for (col_path,) in cols:
+                remainder = col_path[len(prefix) :]
+                first_component = remainder.split("/")[0]
+                if first_component:
+                    children.add(first_component)
+            return sorted(children)

--- a/xandikos/store/vdir.py
+++ b/xandikos/store/vdir.py
@@ -242,7 +242,7 @@ class VdirStore(Store):
         return cls(path)
 
     @classmethod
-    def open_from_path(cls, path: str) -> "VdirStore":
+    def open_from_path(cls, path: str, **kwargs) -> "VdirStore":
         """Open a VdirStore from a path.
 
         Args:

--- a/xandikos/vcard.py
+++ b/xandikos/vcard.py
@@ -62,6 +62,26 @@ class VCardFile(File):
                 ) from exc
         return self._addressbook
 
+    def get_structured_fields(self) -> dict[str, object]:
+        """Extract denormalized fields for SQL storage.
+
+        For vCards, only FN (Formatted Name) maps to summary.
+        """
+        result: dict[str, object] = {
+            "dtstart": None,
+            "dtend": None,
+            "summary": None,
+            "rrule": None,
+            "recurrence_end": None,
+        }
+        try:
+            fn = self.addressbook.fn
+            if fn and fn.value:
+                result["summary"] = str(fn.value)[:1024]
+        except AttributeError:
+            pass
+        return result
+
     def _get_index(self, key: IndexKey) -> IndexValueIterator:
         """Extract index values from a vCard file.
 

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -36,8 +36,6 @@ import socket
 import urllib.parse
 from collections.abc import Iterable, Iterator
 from email.utils import parseaddr
-from dulwich.web import make_wsgi_chain
-from dulwich.server import DictBackend
 from itertools import takewhile
 
 import jinja2
@@ -76,7 +74,7 @@ from xandikos.store import (
 )
 
 from .icalendar import CalendarFilter, ICalendarFile
-from .store.git import GitStore, TreeGitStore
+from .store.registry import get_backend
 from .vcard import VCardFile
 
 logger = getLogger("xandikos")
@@ -373,7 +371,9 @@ class StoreBasedCollection:
     def get_displayname(self) -> str:
         displayname = self.store.get_displayname()
         if displayname is None:
-            return os.path.basename(self.store.repo.path)
+            if self.store.path:
+                return os.path.basename(self.store.path)
+            return ""
         return displayname
 
     def set_displayname(self, displayname: str) -> None:
@@ -420,8 +420,11 @@ class StoreBasedCollection:
                 raise KeyError(name)
             else:
                 # TODO: Properly allow removing subcollections
-                # _subcoll.destroy()
-                shutil.rmtree(os.path.join(self.store.path, name))
+                _subcoll.destroy()
+                if self.store.path is not None:
+                    subpath = os.path.join(self.store.path, name)
+                    if os.path.isdir(subpath):
+                        shutil.rmtree(subpath)
 
     async def create_member(
         self,
@@ -803,10 +806,11 @@ class CollectionSetResource(webdav.Collection):
 
     @classmethod
     def create(cls, backend, relpath):
-        path = backend._map_to_file_path(relpath)
-        if not os.path.isdir(path):
-            os.makedirs(path)
-            logger.info("Creating %s", path)
+        if backend.path is not None:
+            path = backend._map_to_file_path(relpath)
+            if not os.path.isdir(path):
+                os.makedirs(path)
+                logger.info("Creating %s", path)
         return cls(backend, relpath)
 
     def get_displayname(self):
@@ -831,20 +835,18 @@ class CollectionSetResource(webdav.Collection):
         return None
 
     def members(self):
-        p = self.backend._map_to_file_path(self.relpath)
-        for name in os.listdir(p):
-            if name.startswith("."):
-                continue
+        for name in self.backend._list_children(self.relpath):
             resource = self.get_member(name)
-            yield (name, resource)
+            if resource is not None:
+                yield (name, resource)
 
     def get_member(self, name):
         assert name != ""
         relpath = posixpath.join(self.relpath, name)
-        p = self.backend._map_to_file_path(relpath)
-        if not os.path.isdir(p):
+        resource = self.backend.get_resource(relpath)
+        if resource is None:
             raise KeyError(name)
-        return self.backend.get_resource(relpath)
+        return resource
 
     def get_headervalue(self):
         raise KeyError
@@ -873,9 +875,10 @@ class CollectionSetResource(webdav.Collection):
         self.get_member(name).destroy()
 
     def destroy(self):
-        p = self.backend._map_to_file_path(self.relpath)
-        # RFC2518, section 8.6.2 says this should recursively delete.
-        shutil.rmtree(p)
+        if self.backend.path is not None:
+            p = self.backend._map_to_file_path(self.relpath)
+            # RFC2518, section 8.6.2 says this should recursively delete.
+            shutil.rmtree(p)
 
     async def render(
         self, self_url, accepted_content_types, accepted_content_languages
@@ -1048,12 +1051,17 @@ class Principal(webdav.Principal):
         return ret
 
     def set_infit_settings(self, settings):
+        if self.backend.path is None:
+            # Non-filesystem backend: infit settings not supported
+            raise NotImplementedError("infit settings require a filesystem backend")
         relpath = posixpath.join(self.relpath, ".infit")
         p = self.backend._map_to_file_path(relpath)
         with open(p, "w") as f:
             f.write(settings)
 
     def get_infit_settings(self):
+        if self.backend.path is None:
+            raise KeyError
         relpath = posixpath.join(self.relpath, ".infit")
         p = self.backend._map_to_file_path(relpath)
         if not os.path.exists(p):
@@ -1147,8 +1155,19 @@ class PrincipalCollection(Collection, Principal):
 
 
 @functools.lru_cache(maxsize=STORE_CACHE_SIZE)
-def open_store_from_path(path: str, **kwargs):
-    store = GitStore.open_from_path(path, **kwargs)
+def open_store_from_path(
+    path: str,
+    backend_cls: type[Store] | None = None,
+    double_check_indexes: bool = False,
+    index_threshold: int | None = None,
+):
+    if backend_cls is None:
+        backend_cls = get_backend()
+    store = backend_cls.open_from_path(
+        path,
+        double_check_indexes=double_check_indexes,
+        index_threshold=index_threshold,
+    )
     store.load_extra_file_handler(ICalendarFile)
     store.load_extra_file_handler(VCardFile)
     return store
@@ -1156,14 +1175,23 @@ def open_store_from_path(path: str, **kwargs):
 
 class XandikosBackend(webdav.Backend):
     def __init__(
-        self, path, *, paranoid: bool = False, index_threshold: int | None = None
+        self,
+        path,
+        *,
+        paranoid: bool = False,
+        index_threshold: int | None = None,
+        backend: str | None = None,
     ) -> None:
         self.path = path
         self._user_principals: set[str] = set()
         self.paranoid = paranoid
         self.index_threshold = index_threshold
+        self._backend_cls = get_backend(backend)
 
     def _map_to_file_path(self, relpath):
+        if self.path is None:
+            # Non-filesystem backend: use relpath as the logical path
+            return relpath.lstrip("/")
         return os.path.join(self.path, relpath.lstrip("/"))
 
     def _mark_as_principal(self, path):
@@ -1171,7 +1199,7 @@ class XandikosBackend(webdav.Backend):
 
     def create_collection(self, relpath):
         p = self._map_to_file_path(relpath)
-        return Collection(self, relpath, TreeGitStore.create(p))
+        return Collection(self, relpath, self._backend_cls.create(p))
 
     def create_principal(self, relpath, create_defaults=False):
         principal = PrincipalBare.create(self, relpath)
@@ -1183,6 +1211,23 @@ class XandikosBackend(webdav.Backend):
         """List all of the principals on this server."""
         return self._user_principals
 
+    def _is_container(self, relpath, file_path):
+        """Check if a path is a container (collection set or principal)."""
+        if self.path is not None and os.path.isdir(file_path):
+            return True
+        return self._backend_cls.has_collections_under(file_path)
+
+    def _list_children(self, relpath):
+        """List child resource names under a container path."""
+        file_path = self._map_to_file_path(relpath)
+        children = set()
+        if self.path is not None and os.path.isdir(file_path):
+            for name in os.listdir(file_path):
+                if not name.startswith("."):
+                    children.add(name)
+        children.update(self._backend_cls.list_children_under(file_path))
+        return sorted(children)
+
     def get_resource(self, relpath):
         relpath = posixpath.normpath(relpath)
         if not relpath.startswith("/"):
@@ -1192,52 +1237,62 @@ class XandikosBackend(webdav.Backend):
         p = self._map_to_file_path(relpath)
         if p is None:
             return None
-        if os.path.isdir(p):
-            try:
-                store = open_store_from_path(
-                    p,
-                    double_check_indexes=self.paranoid,
-                    index_threshold=self.index_threshold,
-                )
-            except NotStoreError:
-                if relpath in self._user_principals:
-                    return PrincipalBare(self, relpath)
-                return CollectionSetResource(self, relpath)
-            else:
-                return {
-                    STORE_TYPE_CALENDAR: CalendarCollection,
-                    STORE_TYPE_ADDRESSBOOK: AddressbookCollection,
-                    STORE_TYPE_PRINCIPAL: PrincipalCollection,
-                    STORE_TYPE_SCHEDULE_INBOX: ScheduleInbox,
-                    STORE_TYPE_SCHEDULE_OUTBOX: ScheduleOutbox,
-                    STORE_TYPE_SUBSCRIPTION: SubscriptionCollection,
-                    STORE_TYPE_OTHER: Collection,
-                }[store.get_type()](self, relpath, store)
+
+        # 1. Try to open as a store (works for any backend)
+        try:
+            store = open_store_from_path(
+                p,
+                backend_cls=self._backend_cls,
+                double_check_indexes=self.paranoid,
+                index_threshold=self.index_threshold,
+            )
+        except NotStoreError:
+            pass
         else:
-            (basepath, name) = os.path.split(relpath)
-            assert name != "", f"path is {relpath!r}"
-            store = self.get_resource(basepath)
-            if store is None:
-                return None
-            if webdav.COLLECTION_RESOURCE_TYPE not in store.resource_types:
-                return None
-            try:
-                return store.get_member(name)
-            except KeyError:
-                return None
+            return {
+                STORE_TYPE_CALENDAR: CalendarCollection,
+                STORE_TYPE_ADDRESSBOOK: AddressbookCollection,
+                STORE_TYPE_PRINCIPAL: PrincipalCollection,
+                STORE_TYPE_SCHEDULE_INBOX: ScheduleInbox,
+                STORE_TYPE_SCHEDULE_OUTBOX: ScheduleOutbox,
+                STORE_TYPE_SUBSCRIPTION: SubscriptionCollection,
+                STORE_TYPE_OTHER: Collection,
+            }[store.get_type()](self, relpath, store)
+
+        # 2. Not a store — check if it's a principal or collection set
+        if self._is_container(relpath, p):
+            if relpath in self._user_principals:
+                return PrincipalBare(self, relpath)
+            return CollectionSetResource(self, relpath)
+
+        # 3. Try as item member of parent collection
+        (basepath, name) = os.path.split(relpath)
+        assert name != "", f"path is {relpath!r}"
+        parent = self.get_resource(basepath)
+        if parent is None:
+            return None
+        if webdav.COLLECTION_RESOURCE_TYPE not in parent.resource_types:
+            return None
+        try:
+            return parent.get_member(name)
+        except KeyError:
+            return None
 
     async def copy_collection(
         self, source_path: str, dest_path: str, overwrite: bool = True
     ) -> bool:
         """Copy a collection recursively."""
-        import shutil
-
         source_collection = self.get_resource(source_path)
         if source_collection is None:
             raise KeyError(source_path)
 
         if webdav.COLLECTION_RESOURCE_TYPE not in source_collection.resource_types:
             raise ValueError(f"Source '{source_path}' is not a collection")
+
+        if self.path is None:
+            raise NotImplementedError(
+                "copy_collection is not supported for non-filesystem backends"
+            )
 
         source_file_path = self._map_to_file_path(source_path)
         dest_file_path = self._map_to_file_path(dest_path)
@@ -1262,14 +1317,17 @@ class XandikosBackend(webdav.Backend):
         self, source_path: str, dest_path: str, overwrite: bool = True
     ) -> bool:
         """Move a collection recursively."""
-        import shutil
-
         source_collection = self.get_resource(source_path)
         if source_collection is None:
             raise KeyError(source_path)
 
         if webdav.COLLECTION_RESOURCE_TYPE not in source_collection.resource_types:
             raise ValueError(f"Source '{source_path}' is not a collection")
+
+        if self.path is None:
+            raise NotImplementedError(
+                "move_collection is not supported for non-filesystem backends"
+            )
 
         source_file_path = self._map_to_file_path(source_path)
         dest_file_path = self._map_to_file_path(dest_path)
@@ -1402,6 +1460,13 @@ class XandikosApp(webdav.WebDAVApp):
             return await super()._handle_request(request, environ)
 
     def _handle_git_request(self, request, environ, path, start_response):
+        try:
+            from .store.git import GitStore
+            from dulwich.web import make_wsgi_chain
+            from dulwich.server import DictBackend
+        except ImportError:
+            return webdav._send_not_found(request)
+
         resource_path = posixpath.join("/", *path)
         resource = self.backend.get_resource(resource_path)
         if not isinstance(resource, StoreBasedCollection) or not isinstance(
@@ -1649,8 +1714,7 @@ def add_parser(parser):
         "--directory",
         dest="directory",
         default=None,
-        required=True,
-        help="Directory to serve from.",
+        help="Directory to serve from (required for filesystem backends like git/vdir).",
     )
     parser.add_argument(
         "--current-user-principal",
@@ -1686,6 +1750,14 @@ def add_parser(parser):
         default=True,
     )
     parser.add_argument("--debug", action="store_true", help="Print debug messages")
+    parser.add_argument(
+        "--backend",
+        default=None,
+        help=(
+            "Storage backend to use. Built-in options: git (default), vdir, memory, sql. "
+            "Can also be a fully-qualified Python class path."
+        ),
+    )
     # Hidden arguments. These may change without notice in between releases,
     # and are generally just meant for developers.
     parser.add_argument("--paranoid", action="store_true", help=argparse.SUPPRESS)
@@ -1708,24 +1780,40 @@ async def main(options, parser):
 
     logging.basicConfig(level=loglevel, format="%(message)s")
 
+    backend_name = getattr(options, "backend", None) or os.environ.get(
+        "XANDIKOS_BACKEND"
+    )
+
+    # Resolve backend class to check if -d is required
+    backend_cls = get_backend(backend_name)
+
+    directory = options.directory
+    if directory is not None:
+        directory = os.path.abspath(directory)
+    elif backend_cls.uses_filesystem():
+        parser.error(
+            f"-d/--directory is required for the {backend_name or 'git'!r} backend"
+        )
+
     backend = XandikosBackend(
-        os.path.abspath(options.directory),
+        directory,
         paranoid=options.paranoid,
         index_threshold=options.index_threshold,
+        backend=backend_name,
     )
     backend._mark_as_principal(options.current_user_principal)
 
     if options.autocreate or options.defaults:
-        if not os.path.isdir(options.directory):
-            os.makedirs(options.directory)
+        if directory is not None and not os.path.isdir(directory):
+            os.makedirs(directory)
         backend.create_principal(
             options.current_user_principal, create_defaults=options.defaults
         )
 
-    if not os.path.isdir(options.directory):
+    if directory is not None and not os.path.isdir(directory):
         logger.warning(
             "%r does not exist. Run xandikos with --autocreate?",
-            options.directory,
+            directory,
         )
     if not backend.get_resource(options.current_user_principal):
         logger.warning(

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -1758,6 +1758,15 @@ def add_parser(parser):
             "Can also be a fully-qualified Python class path."
         ),
     )
+    parser.add_argument(
+        "--sql-url",
+        default=None,
+        help=(
+            "SQLAlchemy database URL for the SQL backend. "
+            "Overrides XANDIKOS_SQL_URL environment variable. "
+            "Example: sqlite:///xandikos.db or postgresql://user:pass@localhost/xandikos"
+        ),
+    )
     # Hidden arguments. These may change without notice in between releases,
     # and are generally just meant for developers.
     parser.add_argument("--paranoid", action="store_true", help=argparse.SUPPRESS)
@@ -1769,6 +1778,9 @@ async def main(options, parser):
         # TODO(jelmer): Find a way to propagate this without abusing
         # os.environ.
         os.environ["XANDIKOS_DUMP_DAV_XML"] = "1"
+
+    if options.sql_url:
+        os.environ["XANDIKOS_SQL_URL"] = options.sql_url
 
     if not options.route_prefix.endswith("/"):
         options.route_prefix += "/"

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -1784,16 +1784,9 @@ async def main(options, parser):
         "XANDIKOS_BACKEND"
     )
 
-    # Resolve backend class to check if -d is required
-    backend_cls = get_backend(backend_name)
-
     directory = options.directory
     if directory is not None:
         directory = os.path.abspath(directory)
-    elif backend_cls.uses_filesystem():
-        parser.error(
-            f"-d/--directory is required for the {backend_name or 'git'!r} backend"
-        )
 
     backend = XandikosBackend(
         directory,

--- a/xandikos/wsgi.py
+++ b/xandikos/wsgi.py
@@ -23,7 +23,6 @@ from logging import getLogger
 import os
 
 from .web import XandikosApp, XandikosBackend
-from .store.registry import get_backend as _get_backend
 
 logger = getLogger("xandikos")
 
@@ -43,13 +42,7 @@ else:
     autocreate = False
 
 backend_name = os.environ.get("XANDIKOS_BACKEND")
-
-_backend_cls = _get_backend(backend_name)
 _xandikos_path = os.environ.get("XANDIKOSPATH")
-if _xandikos_path is None and _backend_cls.uses_filesystem():
-    raise RuntimeError(
-        f"XANDIKOSPATH environment variable must be set for the {backend_name or 'git'!r} backend"
-    )
 
 backend = XandikosBackend(path=_xandikos_path, backend=backend_name)
 if _xandikos_path is not None and not os.path.isdir(_xandikos_path):


### PR DESCRIPTION
# Pluggable Storage Backend System

## Summary

Introduces a pluggable storage backend architecture that decouples Xandikos
from its hardcoded Git dependency. A backend registry resolves short names
(`git`, `vdir`, `memory`, `sql`) or fully-qualified Python class paths to
`Store` subclasses. Git remains the default. A SQL backend (SQLAlchemy) is
included as the first non-filesystem alternative. Non-filesystem backends
can run without `-d`/`--directory`.

## Changed files

| File | Change | Description |
|------|--------|-------------|
| `xandikos/store/__init__.py` | Modified | Added classmethods to `Store` base: `uses_filesystem()`, `open_from_path()`, `create()`, `has_collections_under()`, `list_children_under()`. Updated `open_store()` to use registry. |
| `xandikos/store/registry.py` | **New** | Backend registry with lazy built-in registration and dotted-path import for third-party backends. |
| `xandikos/store/sql.py` | **New** | Full `Store` implementation backed by SQLAlchemy. ORM model with `collections` and `items` tables. Supports any SQLAlchemy-compatible database. |
| `xandikos/store/git.py` | Modified | `GitStore.create()` delegates to `TreeGitStore.create()` when called on the base class directly. |
| `xandikos/store/vdir.py` | Modified | `open_from_path()` accepts `**kwargs` for interface compatibility. |
| `xandikos/store/memory.py` | Modified | Added `uses_filesystem()` (returns `False`), `open_from_path()`, `create()`, and `self.path = None`. |
| `xandikos/web.py` | Modified | `XandikosBackend` accepts `backend` kwarg, resolves via registry. `open_store_from_path()` accepts `backend_cls`. New `_is_container()` / `_list_children()` methods merge filesystem and backend results. All filesystem operations guarded by `path is not None`. |
| `xandikos/__main__.py` | Modified | `--backend` argument on `serve` and `create-collection`. `-d`/`--directory` optional when `uses_filesystem()` is `False`. |
| `xandikos/wsgi.py` | Modified | Reads `XANDIKOS_BACKEND` env var, validates `XANDIKOSPATH` only for filesystem backends. |
| `tests/test_store.py` | Modified | `SQLStoreTest` (11 tests via `BaseStoreTest` mixin) and `RegistryTest` (7 tests). |
| `NEWS` | Modified | Version 0.4.0 entry. |

## Architecture

```
Store (base class, store/__init__.py)
├── GitStore (store/git.py)         — uses_filesystem=True (default)
│   ├── BareGitStore
│   └── TreeGitStore
├── VdirStore (store/vdir.py)       — uses_filesystem=True
├── MemoryStore (store/memory.py)   — uses_filesystem=False
└── SQLStore (store/sql.py)         — uses_filesystem=False
```

### Registry (`store/registry.py`)

- `register_backend(name, cls)` — register a `Store` subclass under a short name
- `get_backend(name) -> type[Store]` — resolve short name, dotted path, or `None` (default)
- Built-in backends are lazily registered on first `get_backend()` call
- `sql` is only registered when `sqlalchemy` is importable

### Store base class — new classmethods

| Method | Default | Purpose |
|--------|---------|---------|
| `uses_filesystem()` | `True` | Whether `-d`/`--directory` is required |
| `open_from_path(path, **kwargs)` | `NotImplementedError` | Open existing store |
| `create(path)` | `NotImplementedError` | Create new store |
| `has_collections_under(path)` | `False` | Non-filesystem collection discovery |
| `list_children_under(path)` | `[]` | Non-filesystem child enumeration |

### Web layer (`web.py`)

`XandikosBackend` resolves the backend class via registry at init and uses it
throughout. Resource lookup follows a 3-step process:

1. Try `open_store_from_path()` (works for any backend)
2. Check `_is_container()` — combines `os.path.isdir()` (if filesystem) with `backend_cls.has_collections_under()`
3. Try as item member of parent collection

`_list_children()` merges `os.listdir()` results (if filesystem) with
`backend_cls.list_children_under()` for hybrid discovery.

All filesystem operations (`os.path.isdir`, `os.makedirs`, `shutil.rmtree`,
`shutil.copytree`, `shutil.move`, `open()`) are guarded by `path is not None`.

### SQL backend (`store/sql.py`)

**ORM model** (SQLAlchemy Declarative Mapping):

- `collections` — `id`, `path` (unique), `store_type`, `displayname`, `description`, `color`, `comment`, `source_url`, `order`, `refreshrate`, `timezone`, `created_at`, `updated_at`
- `items` — `id`, `collection_id` (FK, CASCADE), `name`, `uid`, `content_type`, `data` (LargeBinary), `etag`, `created_at`, `updated_at`
- Indexes: `UNIQUE(collection_id, name)`, `INDEX(collection_id, uid)`

**Session management**: Engine and session factory cached per DB URL. SQLite
gets WAL mode and foreign keys enabled automatically. Tables are auto-created
via `Base.metadata.create_all()`.

**ETag**: `sha256(data).hexdigest()[:40]`

**CTag**: `sha256(sorted "name:etag" pairs).hexdigest()[:40]`

**`iter_changes()`**: Returns empty — sync-collection falls back to full listing.

## Configuration

```bash
# Git (default, -d required)
xandikos serve -d /data

# SQL with SQLite (no -d needed)
XANDIKOS_BACKEND=sql XANDIKOS_SQL_URL=sqlite:///xandikos.db xandikos serve

# SQL with PostgreSQL
XANDIKOS_BACKEND=sql XANDIKOS_SQL_URL=postgresql://user:pass@localhost/xandikos xandikos serve

# WSGI with SQL
XANDIKOS_BACKEND=sql XANDIKOS_SQL_URL=sqlite:///xandikos.db gunicorn xandikos.wsgi:app

# Third-party backend via dotted path
xandikos serve --backend mypackage.backends.RedisStore
```

## Tests

639 tests passed, 0 regressions.

- `SQLStoreTest` — 11 `BaseStoreTest` methods against SQL backend (SQLite in-memory)
- `RegistryTest` — 7 tests: default backend, resolution by name (git, vdir, memory, sql), unknown backend error, dotted-path import

## QA

| Check | Result |
|-------|--------|
| `ruff check` | All checks passed |
| `ruff format --check` | All files formatted |
| `mypy` | No issues found in 29 source files |
| `pytest` | 639 passed, 7 subtests passed |