### PR TITLE
Fix pycaldav compatibility tests by pinning icalendar version

### DIFF
--- a/compat/pycaldav-requirements.txt
+++ b/compat/pycaldav-requirements.txt
@@ -1,0 +1,11 @@
+# Requirements for pycaldav compatibility tests
+# Pin icalendar to version compatible with pycaldav v1.2.1
+icalendar>=5.0,<6.0
+pytest
+lxml
+requests
+vobject
+recurring-ical-events
+python-dateutil
+pytz
+tzlocal

--- a/compat/xandikos-pycaldav.sh
+++ b/compat/xandikos-pycaldav.sh
@@ -28,8 +28,12 @@ fi
 source "${VENV_DIR}/bin/activate"
 
 # Install pycaldav and test dependencies in the virtual environment
+# Install from requirements file first to pin icalendar version
+pip install -r $(dirname $0)/pycaldav-requirements.txt
+
 pushd $(dirname $0)/pycaldav
-pip install -e . pytest
+# Install pycaldav without dependencies to prevent icalendar upgrade
+pip install -e . --no-deps
 popd
 
 # Deactivate venv before running xandikos so it uses system Python


### PR DESCRIPTION
Pin icalendar to <6.0 to maintain compatibility with pycaldav v1.2.1. The newer icalendar 7.x changed the component_factory API, causing test failures with TypeError: 'module' object is not subscriptable.