### PR TITLE
Support time-range filter on VCALENDAR without comp-filter

### DIFF
--- a/compat/xandikos-caldav-server-tester.sh
+++ b/compat/xandikos-caldav-server-tester.sh
@@ -56,9 +56,6 @@ class TestXandikosCompatibility(unittest.TestCase):
         #
         # Known limitations/unsupported features:
         xandikos_features = FeatureSet({
-            # Component type filtering is required - searches must specify event=True or todo=True
-            "search.comp-type.optional": "unsupported",
-
             # Principal property search returns 403 (not implemented)
             "principal-search": "ungraceful",
 

--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -1161,6 +1161,61 @@ END:VCALENDAR
         result = filter_unbounded.check_from_indexes("test.ics", indexes)
         self.assertTrue(result)
 
+    def test_vcalendar_time_range_without_comp_type(self):
+        """Time-range on VCALENDAR (no child comp-filter) matches subcomponents."""
+        filter = CalendarFilter(ZoneInfo("UTC"))
+        filter.filter_subcomponent("VCALENDAR").filter_time_range(
+            self._tzify(datetime(2015, 3, 10, 22, 35, 12)),
+            self._tzify(datetime(2015, 3, 18, 22, 35, 12)),
+        )
+        # Naive path should match (the VTODO has CREATED=2015-03-14)
+        self.assertTrue(filter.check("file", self.cal))
+
+    def test_vcalendar_time_range_without_comp_type_no_match(self):
+        """Time-range on VCALENDAR returns False when nothing matches."""
+        filter = CalendarFilter(ZoneInfo("UTC"))
+        filter.filter_subcomponent("VCALENDAR").filter_time_range(
+            self._tzify(datetime(2010, 1, 1)),
+            self._tzify(datetime(2010, 1, 2)),
+        )
+        self.assertFalse(filter.check("file", self.cal))
+
+    def test_vcalendar_time_range_index_path(self):
+        """Index-based matching works for time-range on VCALENDAR."""
+        filter = CalendarFilter(ZoneInfo("UTC"))
+        filter.filter_subcomponent("VCALENDAR").filter_time_range(
+            self._tzify(datetime(2015, 3, 10, 22, 35, 12)),
+            self._tzify(datetime(2015, 3, 18, 22, 35, 12)),
+        )
+        # Index keys should include keys for multiple component types
+        keys = filter.index_keys()
+        key_strs = [k for ks in keys for k in ks]
+        self.assertTrue(
+            any("C=VEVENT" in k for k in key_strs),
+            "Should include VEVENT index keys",
+        )
+        self.assertTrue(
+            any("C=VTODO" in k for k in key_strs),
+            "Should include VTODO index keys",
+        )
+
+        # Index-based match with VTODO data
+        self.assertTrue(
+            filter.check_from_indexes(
+                "file",
+                {
+                    "C=VCALENDAR": [True],
+                    "C=VCALENDAR/C=VTODO/P=CREATED": [b"20150314T223512Z"],
+                    "C=VCALENDAR/C=VTODO": [True],
+                    "C=VCALENDAR/C=VTODO/P=DTSTART": [],
+                    "C=VCALENDAR/C=VTODO/P=DUE": [],
+                    "C=VCALENDAR/C=VTODO/P=DURATION": [],
+                    "C=VCALENDAR/C=VTODO/P=COMPLETED": [],
+                    "C=VCALENDAR/C=VTODO/P=RRULE": [],
+                },
+            )
+        )
+
 
 class TextMatchTest(unittest.TestCase):
     def test_default_collation(self):

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -684,6 +684,14 @@ class ComponentTimeRangeMatcher:
     def match(self, comp: Component, tzify: TzifyFunction):
         if comp.name is None:
             raise ValueError("Component has no name in time-range filter")
+        if comp.name == "VCALENDAR":
+            # When time-range is on VCALENDAR itself (no child comp-filter),
+            # match if any subcomponent falls within the time range.
+            return any(
+                self.match(sub, tzify)
+                for sub in comp.subcomponents
+                if sub.name in self.component_handlers
+            )
         try:
             component_handler = self.component_handlers[comp.name]
         except KeyError:
@@ -701,6 +709,21 @@ class ComponentTimeRangeMatcher:
             tzify: Timezone conversion function
             context: Optional context string (e.g. filename) for error/warning reporting
         """
+        if self.comp == "VCALENDAR":
+            # When time-range is on VCALENDAR, try each subcomponent type.
+            for comp_name in self.component_handlers:
+                sub = create_subindexes(indexes, "C=" + comp_name)
+                if sub:
+                    matcher = ComponentTimeRangeMatcher(
+                        self.start, self.end, comp=comp_name
+                    )
+                    try:
+                        if matcher.match_indexes(sub, tzify, context):
+                            return True
+                    except InsufficientIndexDataError:
+                        raise
+            return False
+
         # Check if we have RRULE - if so, expand and test occurrences
         rrule_values = indexes.get("P=RRULE")
         if rrule_values and rrule_values[0]:
@@ -960,6 +983,15 @@ class ComponentTimeRangeMatcher:
         return False
 
     def index_keys(self) -> list[list[str]]:
+        if self.comp == "VCALENDAR":
+            # When time-range is on VCALENDAR, we need index keys for all
+            # component types that could match.
+            keys: list[list[str]] = []
+            for comp_name in ("VEVENT", "VTODO", "VJOURNAL"):
+                sub = ComponentTimeRangeMatcher(self.start, self.end, comp=comp_name)
+                for key_set in sub.index_keys():
+                    keys.append(["C=" + comp_name + "/" + k for k in key_set])
+            return keys
         if self.comp == "VEVENT":
             props = ["DTSTART", "DTEND", "DURATION", "RRULE"]
         elif self.comp == "VTODO":


### PR DESCRIPTION
When a CalDAV REPORT has a time-range on the VCALENDAR comp-filter without a nested VEVENT/VTODO comp-filter (i.e. the client doesn't specify a component type), delegate the time-range check to each subcomponent using the appropriate handler.

This makes the search.comp-type.optional feature work, allowing clients to search for calendar objects without specifying whether they want events or todos.