### PR TITLE
Fix index-based time-range filtering for all-day recurring events

### DIFF
--- a/tests/test_store_regression.py
+++ b/tests/test_store_regression.py
@@ -1,7 +1,7 @@
 """Test for the time-range filtering regression in Store._iter_with_filter_indexes."""
 
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from xandikos.icalendar import (
     ICalendarFile,
@@ -183,6 +183,48 @@ class TimeRangeFilterRegressionTest(unittest.TestCase):
         self.assertFalse(
             cal_filter.check_from_indexes("test.ics", non_matching_indexes)
         )
+
+    def test_allday_recurring_event_index_with_nonutc_timezone(self):
+        """Test that index-based time-range filtering works for all-day recurring events.
+
+        When the calendar's default timezone has a positive UTC offset,
+        the index path used to convert date-only DTSTART to a datetime at
+        midnight UTC, causing apply_time_range_vevent to use point-in-time
+        comparison instead of the all-day (1-day range) comparison. This
+        made the index check return False while the full file check returned
+        True.
+        """
+        store = BareGitStore.create_memory()
+        store.load_extra_file_handler(ICalendarFile)
+        store.index_manager.indexing_threshold = 0
+
+        yearly_allday = (
+            b"BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"
+            b"BEGIN:VEVENT\r\n"
+            b"SUMMARY:yearly recurring all-day event\r\n"
+            b"DTSTART;VALUE=DATE:20000201\r\n"
+            b"UID:yearly_allday\r\n"
+            b"RRULE:FREQ=YEARLY\r\n"
+            b"END:VEVENT\r\nEND:VCALENDAR"
+        )
+        store.import_one("yearly.ics", "text/calendar", [yearly_allday])
+
+        # Use a timezone with positive UTC offset (e.g. UTC+1)
+        # This is the scenario that triggered the bug
+        utc_plus_1 = timezone(timedelta(hours=1))
+        start = datetime(2001, 2, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2001, 2, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+        cal_filter = CalendarFilter(utc_plus_1)
+        comp_filter = ComponentFilter("VCALENDAR")
+        event_filter = ComponentFilter("VEVENT")
+        event_filter.time_range = ComponentTimeRangeMatcher(start, end, comp="VEVENT")
+        comp_filter.children.append(event_filter)
+        cal_filter.children.append(comp_filter)
+
+        matches = list(store.iter_with_filter(cal_filter))
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0][0], "yearly.ics")
 
 
 if __name__ == "__main__":

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -874,6 +874,7 @@ class ComponentTimeRangeMatcher:
             component_handler,
             tzify,
             decode_bytes,
+            dtstart_parsed=dtstart_parsed,
         )
 
     def _calculate_event_duration(
@@ -946,6 +947,7 @@ class ComponentTimeRangeMatcher:
         component_handler,
         tzify,
         decode_bytes,
+        dtstart_parsed: date | datetime | None = None,
     ):
         """Test each occurrence against the time range filter."""
 
@@ -956,14 +958,16 @@ class ComponentTimeRangeMatcher:
         duration_values = indexes.get("P=DURATION", [])
 
         for occurrence in occurrences:
-            # Create occurrence dictionary for component handler
-            if isinstance(occurrence, date) and not isinstance(occurrence, datetime):
-                occurrence_dt = datetime.combine(occurrence, time()).replace(
-                    tzinfo=timezone.utc
-                )
-                occurrence_dict = {"DTSTART": MockProperty(occurrence_dt)}
-            else:
-                occurrence_dict = {"DTSTART": MockProperty(occurrence)}
+            # The rrule library always produces datetime objects, even for
+            # date-only events.  Convert back to match the original DTSTART
+            # type so that the component handler (e.g. apply_time_range_vevent)
+            # uses the correct logic: all-day events get a 1-day implicit
+            # duration, while datetime events use point-in-time comparison.
+            if dtstart_parsed is not None and not isinstance(dtstart_parsed, datetime):
+                # Date-only: extract just the date part
+                if isinstance(occurrence, datetime):
+                    occurrence = occurrence.date()
+            occurrence_dict = {"DTSTART": MockProperty(occurrence)}
 
             # Add DTEND/DUE or DURATION to the occurrence
             if duration_values and duration_values[0]:


### PR DESCRIPTION
When the calendar's default timezone had a positive UTC offset, index-based time-range filtering for VALUE=DATE recurring events would fail to find occurrences at the search boundary.

The rrule library generates datetime objects even for date-only events. The index path passed these datetimes to
apply_time_range_vevent, which used point-in-time comparison (start <= dtstart) instead of the all-day logic (start < dtstart + 1 day). With a non-UTC default timezone, tzify shifted the midnight datetime backwards, causing the boundary check to fail.

Fix by converting rrule datetime occurrences back to date objects when the original DTSTART was date-only, ensuring the correct all-day code path is used.