### PR TITLE
scheduling: Add scheduling-signature helper

### DIFF
--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -20,7 +20,10 @@
 """Tests for xandikos.scheduling (RFC 6638 CalDAV Scheduling)."""
 
 import asyncio
+import hashlib
 import unittest
+
+from icalendar.cal import Calendar
 
 from xandikos import scheduling, webdav
 from xandikos.webdav import ET
@@ -568,6 +571,140 @@ class SchedulingConstantsTests(unittest.TestCase):
         self.assertEqual(
             scheduling.SCHEDULE_OUTBOX_RESOURCE_TYPE,
             "{urn:ietf:params:xml:ns:caldav}schedule-outbox",
+        )
+
+
+class ExtractSchedulingSignatureTests(unittest.TestCase):
+    """Tests for extract_scheduling_signature (RFC 6638 §3.2.10)."""
+
+    BASE_EVENT = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:event-1@example.com
+DTSTAMP:20260101T120000Z
+LAST-MODIFIED:20260101T120000Z
+SEQUENCE:0
+DTSTART:20260601T100000Z
+DTEND:20260601T110000Z
+SUMMARY:Project sync
+ORGANIZER:mailto:alice@example.com
+ATTENDEE;PARTSTAT=ACCEPTED:mailto:alice@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com
+DESCRIPTION:original notes
+END:VEVENT
+END:VCALENDAR
+"""
+
+    def _sig(self, body):
+        return scheduling.extract_scheduling_signature(Calendar.from_ical(body))
+
+    def test_stable_across_dtstamp_changes(self):
+        a = self._sig(self.BASE_EVENT)
+        b = self._sig(self.BASE_EVENT.replace(b"20260101T120000Z", b"20260102T130000Z"))
+        self.assertEqual(a, b)
+
+    def test_changes_when_description_changes(self):
+        a = self._sig(self.BASE_EVENT)
+        b = self._sig(self.BASE_EVENT.replace(b"original notes", b"updated notes"))
+        self.assertNotEqual(a, b)
+
+    def test_changes_when_attendee_added(self):
+        a = self._sig(self.BASE_EVENT)
+        body = (
+            self.BASE_EVENT.decode()
+            .replace(
+                "ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com\n",
+                "ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com\n"
+                "ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:carol@example.com\n",
+            )
+            .encode()
+        )
+        self.assertNotEqual(a, self._sig(body))
+
+    def test_changes_when_dtstart_changes(self):
+        a = self._sig(self.BASE_EVENT)
+        b = self._sig(
+            self.BASE_EVENT.replace(
+                b"DTSTART:20260601T100000Z", b"DTSTART:20260601T110000Z"
+            )
+        )
+        self.assertNotEqual(a, b)
+
+    def test_changes_when_sequence_bumps(self):
+        a = self._sig(self.BASE_EVENT)
+        b = self._sig(self.BASE_EVENT.replace(b"SEQUENCE:0", b"SEQUENCE:1"))
+        self.assertNotEqual(a, b)
+
+    def test_attendee_order_independent(self):
+        reordered = (
+            self.BASE_EVENT.decode()
+            .replace(
+                "ATTENDEE;PARTSTAT=ACCEPTED:mailto:alice@example.com\n"
+                "ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com\n",
+                "ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com\n"
+                "ATTENDEE;PARTSTAT=ACCEPTED:mailto:alice@example.com\n",
+            )
+            .encode()
+        )
+        self.assertEqual(self._sig(self.BASE_EVENT), self._sig(reordered))
+
+    def test_partstat_change_changes_signature(self):
+        replied = self.BASE_EVENT.replace(
+            b"ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com",
+            b"ATTENDEE;PARTSTAT=ACCEPTED:mailto:bob@example.com",
+        )
+        self.assertNotEqual(self._sig(self.BASE_EVENT), self._sig(replied))
+
+    def test_only_vtimezone_yields_empty_digest(self):
+        body = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VTIMEZONE
+TZID:UTC
+END:VTIMEZONE
+END:VCALENDAR
+"""
+        self.assertEqual(self._sig(body), hashlib.sha256().digest())
+
+    def test_recurrence_id_distinguishes_overrides(self):
+        body_with_override = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:rec@example.com
+DTSTAMP:20260101T120000Z
+DTSTART:20260601T100000Z
+SUMMARY:Series
+RRULE:FREQ=DAILY;COUNT=3
+END:VEVENT
+BEGIN:VEVENT
+UID:rec@example.com
+DTSTAMP:20260101T120000Z
+RECURRENCE-ID:20260602T100000Z
+DTSTART:20260602T120000Z
+SUMMARY:Series (override)
+END:VEVENT
+END:VCALENDAR
+"""
+        body_without_override = b"""\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//EN
+BEGIN:VEVENT
+UID:rec@example.com
+DTSTAMP:20260101T120000Z
+DTSTART:20260601T100000Z
+SUMMARY:Series
+RRULE:FREQ=DAILY;COUNT=3
+END:VEVENT
+END:VCALENDAR
+"""
+        self.assertNotEqual(
+            self._sig(body_with_override), self._sig(body_without_override)
         )
 
 

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -55,6 +55,8 @@ class PropTypes(Protocol):
 
     params: Parameters
 
+    def to_ical(self) -> bytes: ...
+
 
 TzifyFunction = Callable[[datetime], datetime]
 

--- a/xandikos/scheduling.py
+++ b/xandikos/scheduling.py
@@ -22,11 +22,16 @@
 See https://tools.ietf.org/html/rfc6638
 """
 
+import hashlib
+
+from icalendar.cal import Calendar
+
 from xandikos import caldav, webdav
 from xandikos.caldav import (
     SCHEDULE_INBOX_RESOURCE_TYPE,
     SCHEDULE_OUTBOX_RESOURCE_TYPE,
 )
+from xandikos.icalendar import PropTypes
 
 # Feature to advertise to indicate scheduling support.
 FEATURE = "calendar-auto-schedule"
@@ -44,6 +49,126 @@ CALENDAR_USER_TYPES = (
     CALENDAR_USER_TYPE_ROOM,
     CALENDAR_USER_TYPE_UNKNOWN,
 )
+
+
+# Properties whose values participate in iTIP scheduling. The schedule-tag
+# (RFC 6638 §3.2.10) only changes when one of these changes within a
+# scheduling-bearing component; bookkeeping properties such as DTSTAMP,
+# LAST-MODIFIED, and CREATED do not affect it.
+SCHEDULING_PROPERTIES = frozenset(
+    {
+        "ATTENDEE",
+        "ORGANIZER",
+        "DTSTART",
+        "DTEND",
+        "DUE",
+        "DURATION",
+        "RRULE",
+        "RDATE",
+        "EXDATE",
+        "RECURRENCE-ID",
+        "SEQUENCE",
+        "STATUS",
+        "SUMMARY",
+        "LOCATION",
+        "DESCRIPTION",
+        "PRIORITY",
+        "TRANSP",
+        "CLASS",
+        "URL",
+        "CATEGORIES",
+        "RESOURCES",
+        "PERCENT-COMPLETE",
+        "REQUEST-STATUS",
+    }
+)
+
+
+# Components that carry scheduling state. Other component types (VTIMEZONE,
+# VALARM, VFREEBUSY responses inside replies, etc.) are intentionally skipped
+# so they do not destabilise the tag.
+SCHEDULING_COMPONENTS = frozenset({"VEVENT", "VTODO", "VJOURNAL"})
+
+
+def _serialize_scheduling_value(value: PropTypes) -> bytes:
+    """Serialise a single iCalendar property value, including its parameters.
+
+    Plain ``to_ical()`` would drop parameters such as ``PARTSTAT`` on
+    ATTENDEE, which is exactly the kind of state the schedule-tag must
+    track. We fold params and value into one sorted, opaque byte string.
+    """
+    rendered = value.to_ical()
+    if value.params:
+        # Parameter names are case-insensitive; normalise to upper for stability.
+        param_items = sorted(
+            (k.upper().encode("ascii"), str(v).encode("utf-8"))
+            for k, v in value.params.items()
+        )
+        rendered = b";".join(b"=".join(item) for item in param_items) + b":" + rendered
+    return rendered
+
+
+def extract_scheduling_signature(cal: Calendar) -> bytes:
+    """Compute a stable signature of the scheduling-relevant content in *cal*.
+
+    Two calendars with the same signature are considered equivalent for the
+    purposes of CalDAV scheduling: a PUT that only changes properties outside
+    SCHEDULING_PROPERTIES (or properties on non-scheduling components) yields
+    the same signature, and therefore the same schedule-tag.
+
+    Args:
+      cal: parsed icalendar Calendar object.
+
+    Returns: opaque ``bytes`` value suitable for hashing or direct comparison.
+    """
+    components: list[tuple[bytes, list[tuple[bytes, list[bytes]]]]] = []
+    for component in cal.subcomponents:
+        if component.name is None:
+            continue
+        name = component.name.upper()
+        if name not in SCHEDULING_COMPONENTS:
+            continue
+        try:
+            uid = component["UID"].to_ical()
+        except KeyError:
+            uid = b""
+        try:
+            recurrence_id = component["RECURRENCE-ID"].to_ical()
+        except KeyError:
+            recurrence_id = b""
+        props: list[tuple[bytes, list[bytes]]] = []
+        for field in component:
+            if field.upper() not in SCHEDULING_PROPERTIES:
+                continue
+            value = component.get(field)
+            if value is None:
+                continue
+            if isinstance(value, list):
+                items = [_serialize_scheduling_value(v) for v in value]
+            else:
+                items = [_serialize_scheduling_value(value)]
+            items.sort()
+            props.append((field.upper().encode("ascii"), items))
+        props.sort()
+        components.append(
+            (name.encode("ascii") + b":" + uid + b":" + recurrence_id, props)
+        )
+    components.sort()
+
+    h = hashlib.sha256()
+    for comp_key, props in components:
+        h.update(b"C\x00")
+        h.update(comp_key)
+        h.update(b"\x00")
+        for field_name, items in props:
+            h.update(b"P\x00")
+            h.update(field_name)
+            h.update(b"\x00")
+            for item in items:
+                h.update(b"V\x00")
+                h.update(item)
+                h.update(b"\x00")
+    return h.digest()
 
 
 class ScheduleInbox(webdav.Collection):


### PR DESCRIPTION
Introduce extract_scheduling_signature(cal), which reduces a parsed calendar to a stable SHA-256 digest over only the iTIP-relevant properties on VEVENT/VTODO/VJOURNAL components. ATTENDEE parameters (notably PARTSTAT) are folded into the digest so attendee responses register as scheduling changes; bookkeeping properties such as DTSTAMP and LAST-MODIFIED do not.

This is groundwork for the CalDAV schedule-tag (RFC 6638 §3.2.10): two revisions with the same signature share a schedule-tag, while revisions whose scheduling state differs do not.