### PR TITLE
scheduling: Wire schedule-tag through to ObjectResource

### DIFF
--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -292,7 +292,7 @@ class ScheduleTagPropertyTests(unittest.TestCase):
                 def get_content_type(self):
                     return "text/calendar"
 
-                def get_schedule_tag(self):
+                async def get_schedule_tag(self):
                     return "schedule-tag-12345"
 
             resource = MockResource()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -19,6 +19,7 @@
 
 """Tests for xandikos.web."""
 
+import asyncio
 import os
 import shutil
 import tempfile
@@ -29,6 +30,7 @@ from xandikos.icalendar import ICalendarFile
 from xandikos.store.git import TreeGitStore
 from xandikos.web import (
     CalendarCollection,
+    ObjectResource,
     SingleUserFilesystemBackend,
     XandikosApp,
 )
@@ -640,3 +642,90 @@ END:VCALENDAR""")
         self.assertNotIn(".xandikos", all_names)
         self.assertNotIn(".xandikos/config", all_names)
         self.assertNotIn(".xandikos/availability.ics", all_names)
+
+
+SCHEDULING_BASE = b"""\
+BEGIN:VCALENDAR\r
+VERSION:2.0\r
+PRODID:-//Test//EN\r
+BEGIN:VEVENT\r
+UID:meeting@example.com\r
+DTSTAMP:20260101T120000Z\r
+SEQUENCE:0\r
+DTSTART:20260601T100000Z\r
+DTEND:20260601T110000Z\r
+SUMMARY:Sync\r
+ORGANIZER:mailto:alice@example.com\r
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com\r
+DESCRIPTION:original\r
+END:VEVENT\r
+END:VCALENDAR\r
+"""
+
+
+class ObjectResourceScheduleTagTests(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir)
+
+        self.store = TreeGitStore.create(os.path.join(self.tempdir, "c"))
+        self.store.load_extra_file_handler(ICalendarFile)
+
+    def _put(self, name: str, body: bytes) -> str:
+        _, etag = self.store.import_one(name, "text/calendar", [body])
+        return etag
+
+    def _resource(self, name: str, etag: str) -> ObjectResource:
+        return ObjectResource(self.store, name, "text/calendar", etag)
+
+    def test_schedule_tag_is_strong_etag_format(self):
+        etag = self._put("event.ics", SCHEDULING_BASE)
+        tag = asyncio.run(self._resource("event.ics", etag).get_schedule_tag())
+        # Strong etag: surrounded by double quotes, content is hex.
+        self.assertTrue(tag.startswith('"') and tag.endswith('"'))
+        self.assertEqual(64, len(tag) - 2)  # sha256 hex
+
+    def test_schedule_tag_stable_across_dtstamp_change(self):
+        etag1 = self._put("event.ics", SCHEDULING_BASE)
+        tag1 = asyncio.run(self._resource("event.ics", etag1).get_schedule_tag())
+
+        rewritten = SCHEDULING_BASE.replace(
+            b"DTSTAMP:20260101T120000Z", b"DTSTAMP:20260201T120000Z"
+        )
+        etag2 = self._put("event.ics", rewritten)
+        tag2 = asyncio.run(self._resource("event.ics", etag2).get_schedule_tag())
+
+        self.assertEqual(tag1, tag2)
+
+    def test_schedule_tag_changes_on_attendee_partstat(self):
+        etag1 = self._put("event.ics", SCHEDULING_BASE)
+        tag1 = asyncio.run(self._resource("event.ics", etag1).get_schedule_tag())
+
+        replied = SCHEDULING_BASE.replace(
+            b"PARTSTAT=NEEDS-ACTION", b"PARTSTAT=ACCEPTED"
+        )
+        etag2 = self._put("event.ics", replied)
+        tag2 = asyncio.run(self._resource("event.ics", etag2).get_schedule_tag())
+
+        self.assertNotEqual(tag1, tag2)
+
+    def test_schedule_tag_changes_on_description_change(self):
+        # DESCRIPTION is in SCHEDULING_PROPERTIES — RFC 6638 considers it
+        # part of the iTIP payload, so the tag must move.
+        etag1 = self._put("event.ics", SCHEDULING_BASE)
+        tag1 = asyncio.run(self._resource("event.ics", etag1).get_schedule_tag())
+
+        edited = SCHEDULING_BASE.replace(b"DESCRIPTION:original", b"DESCRIPTION:edited")
+        etag2 = self._put("event.ics", edited)
+        tag2 = asyncio.run(self._resource("event.ics", etag2).get_schedule_tag())
+
+        self.assertNotEqual(tag1, tag2)
+
+    def test_schedule_tag_rejects_non_calendar(self):
+        async def run():
+            resource = ObjectResource(self.store, "x", "text/plain", "etag")
+            with self.assertRaises(KeyError):
+                await resource.get_schedule_tag()
+
+        asyncio.run(run())

--- a/xandikos/scheduling.py
+++ b/xandikos/scheduling.py
@@ -326,7 +326,7 @@ class ScheduleTagProperty(webdav.Property):
         return resource.get_content_type() == "text/calendar"
 
     async def get_value(self, base_href, resource, el, environ):
-        el.text = resource.get_schedule_tag()
+        el.text = await resource.get_schedule_tag()
 
 
 class CalendarUserTypeProperty(webdav.Property):

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -76,7 +76,9 @@ from xandikos.store import (
     Store,
 )
 
-from .icalendar import CalendarFilter
+from icalendar.cal import Calendar
+
+from .icalendar import CalendarFilter, ICalendarFile
 from .store.git import GitStore, TreeGitStore
 
 logger = getLogger("xandikos")
@@ -296,9 +298,15 @@ class ObjectResource(webdav.Resource):
         # TODO(jelmer): Ask the store?
         raise KeyError
 
-    def get_schedule_tag(self):
-        # TODO(jelmer): Ask the store?
-        raise KeyError
+    async def get_schedule_tag(self) -> str:
+        if self.content_type != "text/calendar":
+            raise KeyError
+        file = await self.get_file()
+        assert isinstance(file, ICalendarFile)
+        cal = file.calendar
+        assert isinstance(cal, Calendar)
+        signature = scheduling.extract_scheduling_signature(cal)
+        return create_strong_etag(signature.hex())
 
 
 class StoreBasedCollection:


### PR DESCRIPTION
Replace the KeyError stub on ObjectResource.get_schedule_tag with a real implementation that derives the tag from
extract_scheduling_signature() of the parsed calendar. Two revisions that differ only in DTSTAMP, LAST-MODIFIED, or other non-scheduling properties produce the same tag; iTIP-significant changes (ATTENDEE adds, PARTSTAT updates, DTSTART moves, etc.) flip it.

ScheduleTagProperty.get_value now awaits get_schedule_tag, since the implementation needs to load and parse the file from the store.