### PR TITLE
compat: Fix CI failures from caldav 3.2.0 / icalendar 7.x bump

### DIFF
--- a/compat/pycaldav-requirements.txt
+++ b/compat/pycaldav-requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for pycaldav compatibility tests
 # Pin icalendar <7.0: pycaldav uses icalendar.cal.component_factory as a dict,
 # but in icalendar 7.x it became a module (need ComponentFactory() instead).
-icalendar>=5.0,<8.0
+icalendar>=5.0,<7.0
 pytest
 lxml
 requests

--- a/compat/xandikos-caldav-server-tester.sh
+++ b/compat/xandikos-caldav-server-tester.sh
@@ -58,7 +58,11 @@ class TestXandikosCompatibility(unittest.TestCase):
         xandikos_features = FeatureSet({
             # Principal property search returns 403 (not implemented)
             "principal-search": "ungraceful",
-
+            # RFC6638 scheduling: ScheduleInbox/Outbox are stubs that raise
+            # NotImplementedError, and the DAV header advertises the legacy
+            # "calendar-auto-scheduling" token rather than RFC6638's
+            # "calendar-auto-schedule".
+            "scheduling": "unsupported",
         })
 
         cls.caldav = caldav.DAVClient(


### PR DESCRIPTION
The dependabot bump in #638 broke two compat suites:

- pycaldav indexes `icalendar.cal.component_factory` as a dict, which only works on icalendar < 7.0 (the comment in the requirements file already noted this); restore the upper bound the bump relaxed.
- the newer caldav-server-tester from git probes scheduling and asserts observed-vs-expected. Xandikos's ScheduleInbox/Outbox are stubs and the DAV header advertises the legacy "calendar-auto-scheduling" token rather than RFC6638's "calendar-auto-schedule", so client.supports_scheduling() returns False; declare scheduling unsupported in the test FeatureSet so the assertion matches.