### PR TITLE
webdav: Honor If-Schedule-Tag-Match on PUT and DELETE

### DIFF
--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -100,10 +100,12 @@ class WebTests(WebTestCase):
         contents = b"".join(app(environ, start_response))
         return _code[0], _headers, contents
 
-    def delete(self, app, path, if_match=None):
+    def delete(self, app, path, if_match=None, if_schedule_tag_match=None):
         environ = {"PATH_INFO": path, "REQUEST_METHOD": "DELETE"}
         if if_match is not None:
             environ["HTTP_IF_MATCH"] = if_match
+        if if_schedule_tag_match is not None:
+            environ["HTTP_IF_SCHEDULE_TAG_MATCH"] = if_schedule_tag_match
         setup_testing_defaults(environ)
         _code = []
         _headers = []
@@ -130,7 +132,15 @@ class WebTests(WebTestCase):
         contents = b"".join(app(environ, start_response))
         return _code[0], _headers, contents
 
-    def put(self, app, path, contents, if_match=None, if_none_match=None):
+    def put(
+        self,
+        app,
+        path,
+        contents,
+        if_match=None,
+        if_none_match=None,
+        if_schedule_tag_match=None,
+    ):
         environ = {
             "PATH_INFO": path,
             "REQUEST_METHOD": "PUT",
@@ -140,6 +150,8 @@ class WebTests(WebTestCase):
             environ["HTTP_IF_MATCH"] = if_match
         if if_none_match is not None:
             environ["HTTP_IF_NONE_MATCH"] = if_none_match
+        if if_schedule_tag_match is not None:
+            environ["HTTP_IF_SCHEDULE_TAG_MATCH"] = if_schedule_tag_match
         setup_testing_defaults(environ)
         _code = []
         _headers = []
@@ -814,6 +826,156 @@ class WebTests(WebTestCase):
         )
         code, headers, contents = self.delete(
             app, "/collection/resource", if_match='"wrong-etag"'
+        )
+        self.assertEqual("412 Precondition Failed", code)
+
+    # RFC 6638 Section 8.1 - If-Schedule-Tag-Match tests
+    def test_rfc6638_8_1_put_if_schedule_tag_match_success(self):
+        """PUT with matching If-Schedule-Tag-Match succeeds (RFC 6638 §8.1)."""
+
+        class TestResource(Resource):
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def get_schedule_tag(self):
+                return '"sched-1"'
+
+            async def set_body(
+                self, body, replace_etag=None, remote_user=None, requester=None
+            ):
+                return '"etag-2"'
+
+        app = self.makeApp({"/resource": TestResource()}, [])
+        code, _ = self.put(
+            app,
+            "/resource",
+            b"new content",
+            if_schedule_tag_match='"sched-1"',
+        )
+        self.assertEqual("204 No Content", code)
+
+    def test_rfc6638_8_1_put_if_schedule_tag_match_fail(self):
+        """PUT with stale If-Schedule-Tag-Match returns 412 (RFC 6638 §8.1)."""
+
+        class TestResource(Resource):
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def get_schedule_tag(self):
+                return '"sched-1"'
+
+            async def set_body(
+                self, body, replace_etag=None, remote_user=None, requester=None
+            ):
+                self.fail("set_body should not be called")  # pragma: no cover
+
+        app = self.makeApp({"/resource": TestResource()}, [])
+        code, _ = self.put(
+            app,
+            "/resource",
+            b"new content",
+            if_schedule_tag_match='"old-sched"',
+        )
+        self.assertEqual("412 Precondition Failed", code)
+
+    def test_rfc6638_8_1_put_if_schedule_tag_match_resource_has_no_schedule_tag(self):
+        """If the resource has no schedule-tag the precondition fails."""
+
+        class TestResource(Resource):
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def set_body(
+                self, body, replace_etag=None, remote_user=None, requester=None
+            ):
+                return '"etag-2"'
+
+        app = self.makeApp({"/resource": TestResource()}, [])
+        code, _ = self.put(
+            app,
+            "/resource",
+            b"new content",
+            if_schedule_tag_match='"sched-1"',
+        )
+        self.assertEqual("412 Precondition Failed", code)
+
+    def test_rfc6638_8_1_put_if_schedule_tag_match_wildcard(self):
+        """If-Schedule-Tag-Match: * matches any existing schedule-tag."""
+
+        class TestResource(Resource):
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def get_schedule_tag(self):
+                return '"sched-1"'
+
+            async def set_body(
+                self, body, replace_etag=None, remote_user=None, requester=None
+            ):
+                return '"etag-2"'
+
+        app = self.makeApp({"/resource": TestResource()}, [])
+        code, _ = self.put(app, "/resource", b"new content", if_schedule_tag_match="*")
+        self.assertEqual("204 No Content", code)
+
+    def test_rfc6638_8_1_delete_if_schedule_tag_match_success(self):
+        """DELETE with matching If-Schedule-Tag-Match succeeds."""
+        deleted_items = []
+
+        class TestResource(Resource):
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def get_schedule_tag(self):
+                return '"sched-1"'
+
+        class TestCollection(Collection):
+            def delete_member(self, name, etag=None, remote_user=None, requester=None):
+                deleted_items.append((name, etag))
+
+            def get_member(self, name):
+                if name == "resource":
+                    return TestResource()
+                raise KeyError(name)
+
+            def members(self):
+                return [("resource", TestResource())]
+
+        app = self.makeApp(
+            {"/collection": TestCollection(), "/collection/resource": TestResource()},
+            [],
+        )
+        code, _, _ = self.delete(
+            app, "/collection/resource", if_schedule_tag_match='"sched-1"'
+        )
+        self.assertEqual("204 No Content", code)
+        self.assertEqual(1, len(deleted_items))
+
+    def test_rfc6638_8_1_delete_if_schedule_tag_match_fail(self):
+        """DELETE with stale If-Schedule-Tag-Match returns 412."""
+
+        class TestResource(Resource):
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def get_schedule_tag(self):
+                return '"sched-1"'
+
+        class TestCollection(Collection):
+            def delete_member(self, name, etag=None, remote_user=None, requester=None):
+                self.fail("delete_member should not be called")  # pragma: no cover
+
+            def get_member(self, name):
+                if name == "resource":
+                    return TestResource()
+                raise KeyError(name)
+
+        app = self.makeApp(
+            {"/collection": TestCollection(), "/collection/resource": TestResource()},
+            [],
+        )
+        code, _, _ = self.delete(
+            app, "/collection/resource", if_schedule_tag_match='"old-sched"'
         )
         self.assertEqual("412 Precondition Failed", code)
 

--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -489,6 +489,14 @@ class Resource:
         """
         raise NotImplementedError(self.get_etag)
 
+    async def get_schedule_tag(self) -> str:
+        """Get the CalDAV schedule-tag for this resource.
+
+        See RFC 6638 §3.2.10. Resources that are not scheduling object
+        resources MUST raise KeyError.
+        """
+        raise KeyError
+
     async def get_body(self) -> Iterable[bytes]:
         """Get resource contents.
 
@@ -1974,6 +1982,14 @@ class DeleteMethod(Method):
         if_match = request.headers.get("If-Match", None)
         if if_match is not None and not etag_matches(if_match, current_etag):
             return Response(status=412, reason="Precondition Failed")
+        if_schedule_tag_match = request.headers.get("If-Schedule-Tag-Match", None)
+        if if_schedule_tag_match is not None:
+            try:
+                current_schedule_tag = await r.get_schedule_tag()
+            except KeyError:
+                current_schedule_tag = None
+            if not etag_matches(if_schedule_tag_match, current_schedule_tag):
+                return Response(status=412, reason="Precondition Failed")
         pr.delete_member(
             item_name,
             current_etag,
@@ -2041,6 +2057,16 @@ class PutMethod(Method):
         if_none_match = request.headers.get("If-None-Match", None)
         if if_none_match and etag_matches(if_none_match, current_etag):
             return Response(status="412 Precondition Failed")
+        if_schedule_tag_match = request.headers.get("If-Schedule-Tag-Match", None)
+        if if_schedule_tag_match is not None:
+            current_schedule_tag = None
+            if r is not None:
+                try:
+                    current_schedule_tag = await r.get_schedule_tag()
+                except KeyError:
+                    pass
+            if not etag_matches(if_schedule_tag_match, current_schedule_tag):
+                return Response(status="412 Precondition Failed")
         if r is not None:
             # Item already exists; update it
             try:


### PR DESCRIPTION
Implement the precondition handling described in RFC 6638 §8.1. Adds an async get_schedule_tag stub to webdav.Resource (raising KeyError to mean "no schedule-tag applies") and consults it from the PUT and DELETE handlers when an If-Schedule-Tag-Match request header is present. A stale or missing schedule-tag yields 412 and the underlying mutation is skipped.