### PR TITLE
webdav: Emit Schedule-Tag response header

### DIFF
--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -979,6 +979,119 @@ class WebTests(WebTestCase):
         )
         self.assertEqual("412 Precondition Failed", code)
 
+    # RFC 6638 Section 8.2 - Schedule-Tag response header tests
+    def test_rfc6638_8_2_get_emits_schedule_tag(self):
+        """GET on a scheduling resource includes the Schedule-Tag header."""
+
+        class TestResource(Resource):
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def get_schedule_tag(self):
+                return '"sched-1"'
+
+            async def render(
+                self, self_url, accepted_content_types, accepted_languages
+            ):
+                return ([b"x"], 1, '"etag-1"', "text/calendar", None)
+
+            def get_last_modified(self):
+                raise KeyError
+
+        app = self.makeApp({"/event.ics": TestResource()}, [])
+        code, headers, _ = self.get(app, "/event.ics")
+        self.assertEqual("200 OK", code)
+        self.assertIn(("Schedule-Tag", '"sched-1"'), headers)
+
+    def test_rfc6638_8_2_get_omits_schedule_tag_for_non_scheduling_resource(self):
+        """GET on a non-scheduling resource omits the Schedule-Tag header."""
+
+        class TestResource(Resource):
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def render(
+                self, self_url, accepted_content_types, accepted_languages
+            ):
+                return ([b"x"], 1, '"etag-1"', "text/plain", None)
+
+            def get_last_modified(self):
+                raise KeyError
+
+        app = self.makeApp({"/note.txt": TestResource()}, [])
+        code, headers, _ = self.get(app, "/note.txt")
+        self.assertEqual("200 OK", code)
+        header_names = [name for name, _ in headers]
+        self.assertNotIn("Schedule-Tag", header_names)
+
+    def test_rfc6638_8_2_put_update_emits_schedule_tag(self):
+        """PUT update on scheduling resource sends Schedule-Tag header."""
+
+        class TestResource(Resource):
+            tag_value = '"sched-1"'
+
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def get_schedule_tag(self):
+                return type(self).tag_value
+
+            async def set_body(
+                self, body, replace_etag=None, remote_user=None, requester=None
+            ):
+                # Simulate a scheduling change.
+                type(self).tag_value = '"sched-2"'
+                return '"etag-2"'
+
+        app = self.makeApp({"/event.ics": TestResource()}, [])
+        code, headers = self.put(app, "/event.ics", b"new content")
+        self.assertEqual("204 No Content", code)
+        self.assertIn(("Schedule-Tag", '"sched-2"'), headers)
+
+    def test_rfc6638_8_2_put_create_emits_schedule_tag(self):
+        """PUT create on scheduling resource sends Schedule-Tag header."""
+
+        class CreatedResource(Resource):
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def get_schedule_tag(self):
+                return '"sched-new"'
+
+        class TestCollection(Collection):
+            async def create_member(
+                self, name, contents, content_type, remote_user=None, requester=None
+            ):
+                return (name, '"etag-1"')
+
+            def get_member(self, name):
+                if name == "newitem.ics":
+                    return CreatedResource()
+                raise KeyError(name)
+
+        app = self.makeApp({"/coll": TestCollection()}, [])
+        code, headers = self.put(app, "/coll/newitem.ics", b"data")
+        self.assertEqual("201 Created", code)
+        self.assertIn(("Schedule-Tag", '"sched-new"'), headers)
+
+    def test_rfc6638_8_2_put_update_omits_schedule_tag_for_non_scheduling(self):
+        """PUT update on non-scheduling resource omits Schedule-Tag."""
+
+        class TestResource(Resource):
+            async def get_etag(self):
+                return '"etag-1"'
+
+            async def set_body(
+                self, body, replace_etag=None, remote_user=None, requester=None
+            ):
+                return '"etag-2"'
+
+        app = self.makeApp({"/note.txt": TestResource()}, [])
+        code, headers = self.put(app, "/note.txt", b"data")
+        self.assertEqual("204 No Content", code)
+        header_names = [name for name, _ in headers]
+        self.assertNotIn("Schedule-Tag", header_names)
+
     # RFC 4918 Section 9.1/9.2 - Multi-Status error scenario tests
     def test_rfc4918_propfind_mixed_success_failure(self):
         """Test PROPFIND with mix of found and not-found properties."""

--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -262,6 +262,20 @@ class NeedsMultiStatus(Exception):
     """Raised when a response needs multi-status (e.g. for propstat)."""
 
 
+async def _maybe_schedule_tag_header(resource):
+    """Return a (header_name, value) tuple for the Schedule-Tag header.
+
+    Returns None if the resource has no schedule-tag (e.g. it's not a
+    scheduling object resource). See RFC 6638 §8.2.
+    """
+    if resource is None:
+        return None
+    try:
+        return ("Schedule-Tag", await resource.get_schedule_tag())
+    except KeyError:
+        return None
+
+
 def propstat_by_status(propstat):
     """Sort a list of propstatus objects by HTTP status.
 
@@ -2090,7 +2104,12 @@ class PutMethod(Method):
                     await app._get_allowed_methods(request, environ)
                 )
             else:
-                return Response(status="204 No Content", headers=[("ETag", new_etag)])
+                headers = [("ETag", new_etag)]
+                fresh = app.backend.get_resource(path)
+                schedule_tag_header = await _maybe_schedule_tag_header(fresh)
+                if schedule_tag_header is not None:
+                    headers.append(schedule_tag_header)
+                return Response(status="204 No Content", headers=headers)
         content_type = request.content_type
         container_path, name = split_path_preserving_encoding(request, environ)
         r = app.backend.get_resource(container_path)
@@ -2120,7 +2139,15 @@ class PutMethod(Method):
             return Response(status=507, reason="Insufficient Storage")
         except ResourceLocked:
             return Response(status=423, reason="Resource Locked")
-        return Response(status=201, reason="Created", headers=[("ETag", new_etag)])
+        headers = [("ETag", new_etag)]
+        try:
+            fresh = r.get_member(new_name)
+        except (KeyError, NotImplementedError):
+            fresh = None
+        schedule_tag_header = await _maybe_schedule_tag_header(fresh)
+        if schedule_tag_header is not None:
+            headers.append(schedule_tag_header)
+        return Response(status=201, reason="Created", headers=headers)
 
 
 class MoveMethod(Method):
@@ -2792,6 +2819,9 @@ async def _do_get(request, environ, app, send_body):
         headers.append(("Last-Modified", last_modified))
     if content_languages is not None:
         headers.append(("Content-Language", ", ".join(content_languages)))
+    schedule_tag_header = await _maybe_schedule_tag_header(r)
+    if schedule_tag_header is not None:
+        headers.append(schedule_tag_header)
     if send_body:
         return Response(body=body, status=200, reason="OK", headers=headers)
     else:


### PR DESCRIPTION
Per RFC 6638 §8.2, GET responses on a scheduling object resource and PUT responses that create or update one MUST carry the Schedule-Tag response header. Compute it on the way out via a small helper that swallows KeyError so non-scheduling resources are silently skipped.

For PUT updates the post-write schedule-tag is read from a freshly looked-up resource handle so the cache from the pre-write read does not leak into the response.