### PR TITLE
 scheduling: Implement free-busy POST handler on schedule-outbox

### DIFF
--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -708,5 +708,133 @@ END:VCALENDAR
         )
 
 
+FREEBUSY_REQUEST = b"""\
+BEGIN:VCALENDAR\r
+VERSION:2.0\r
+PRODID:-//Test//EN\r
+METHOD:REQUEST\r
+BEGIN:VFREEBUSY\r
+UID:fb-1@example.com\r
+DTSTAMP:20260601T080000Z\r
+DTSTART:20260601T000000Z\r
+DTEND:20260602T000000Z\r
+ORGANIZER:mailto:alice@example.com\r
+ATTENDEE:mailto:alice@example.com\r
+ATTENDEE:mailto:bob@example.com\r
+END:VFREEBUSY\r
+END:VCALENDAR\r
+"""
+
+
+class _FakeRequest:
+    headers: dict[str, str] = {}
+
+
+class _FakeOutbox(scheduling.ScheduleOutbox):
+    """Outbox where the principal is alice@example.com with one busy hour."""
+
+    def __init__(self, busy_periods=None):
+        from datetime import datetime, timezone
+
+        from icalendar.prop import vPeriod
+
+        self._busy = busy_periods or [
+            vPeriod(
+                (
+                    datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc),
+                    datetime(2026, 6, 1, 11, 0, tzinfo=timezone.utc),
+                )
+            )
+        ]
+
+    async def get_attendee_busy_periods(self, attendee_address, start, end):
+        if attendee_address == "mailto:alice@example.com":
+            return self._busy
+        return None
+
+
+CALDAV_NS = "{urn:ietf:params:xml:ns:caldav}"
+
+
+class ScheduleOutboxFreeBusyTests(unittest.TestCase):
+    """Tests for ScheduleOutbox free-busy POST handling (RFC 6638 §6)."""
+
+    def _post(self, outbox, body=FREEBUSY_REQUEST, content_type="text/calendar"):
+        return asyncio.run(
+            outbox.handle_post(_FakeRequest(), {}, "/p/outbox/", [body], content_type)
+        )
+
+    def test_success_returns_schedule_response(self):
+        outbox = _FakeOutbox()
+        response = self._post(outbox)
+
+        self.assertEqual(200, response.status)
+        body_xml = b"".join(response.body)
+        root = ET.fromstring(body_xml)
+        self.assertEqual(CALDAV_NS + "schedule-response", root.tag)
+        responses = root.findall(CALDAV_NS + "response")
+        self.assertEqual(2, len(responses))
+
+        recipients = {
+            r.find(CALDAV_NS + "recipient/{DAV:}href").text: r for r in responses
+        }
+        # Local user gets a calendar-data REPLY.
+        alice = recipients["mailto%3Aalice%40example.com"]
+        self.assertEqual(
+            scheduling.REQUEST_STATUS_SUCCESS,
+            alice.find(CALDAV_NS + "request-status").text,
+        )
+        cd = alice.find(CALDAV_NS + "calendar-data").text
+        self.assertIn("METHOD:REPLY", cd)
+        self.assertIn("20260601T100000Z/20260601T110000Z", cd)
+        self.assertIn("FREEBUSY", cd)
+
+        # Unknown user gets 3.8 No authority and no calendar-data.
+        bob = recipients["mailto%3Abob%40example.com"]
+        self.assertEqual(
+            scheduling.REQUEST_STATUS_NO_AUTHORITY,
+            bob.find(CALDAV_NS + "request-status").text,
+        )
+        self.assertIsNone(bob.find(CALDAV_NS + "calendar-data"))
+
+    def test_rejects_non_calendar_content_type(self):
+        response = self._post(_FakeOutbox(), content_type="application/json")
+        self.assertEqual(415, response.status)
+
+    def test_rejects_request_without_method_request(self):
+        body = FREEBUSY_REQUEST.replace(b"METHOD:REQUEST\r\n", b"")
+        with self.assertRaises(webdav.BadRequestError):
+            self._post(_FakeOutbox(), body=body)
+
+    def test_rejects_missing_attendee(self):
+        body = FREEBUSY_REQUEST.replace(
+            b"ATTENDEE:mailto:alice@example.com\r\nATTENDEE:mailto:bob@example.com\r\n",
+            b"",
+        )
+        with self.assertRaises(webdav.BadRequestError):
+            self._post(_FakeOutbox(), body=body)
+
+    def test_rejects_missing_organizer(self):
+        body = FREEBUSY_REQUEST.replace(b"ORGANIZER:mailto:alice@example.com\r\n", b"")
+        with self.assertRaises(webdav.BadRequestError):
+            self._post(_FakeOutbox(), body=body)
+
+    def test_rejects_extra_components(self):
+        body = FREEBUSY_REQUEST.replace(
+            b"END:VCALENDAR\r\n",
+            b"BEGIN:VEVENT\r\nUID:e\r\nDTSTAMP:20260101T000000Z\r\nDTSTART:20260101T000000Z\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+        )
+        with self.assertRaises(webdav.BadRequestError):
+            self._post(_FakeOutbox(), body=body)
+
+    def test_default_get_attendee_busy_periods_returns_none(self):
+        # The base class refuses to answer for any attendee.
+        outbox = scheduling.ScheduleOutbox()
+        result = asyncio.run(
+            outbox.get_attendee_busy_periods("mailto:anyone@example.com", None, None)
+        )
+        self.assertIsNone(result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -729,3 +729,72 @@ class ObjectResourceScheduleTagTests(unittest.TestCase):
                 await resource.get_schedule_tag()
 
         asyncio.run(run())
+
+
+class ScheduleOutboxLookupTests(unittest.TestCase):
+    """Integration tests for ScheduleOutbox.get_attendee_busy_periods."""
+
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir)
+        self.backend = SingleUserFilesystemBackend(self.tempdir)
+        # Pass an absolute path so the principal is registered under the same
+        # key the resource lookup uses.
+        self.backend.create_principal("/user", create_defaults=True)
+        # Inject a known calendar-user-address-set on the principal so we
+        # don't depend on the EMAIL environment variable.
+        os.environ["EMAIL"] = "user@example.com"
+        self.addCleanup(os.environ.pop, "EMAIL", None)
+
+    def _put_event(self, body):
+        cal = self.backend.get_resource("/user/calendars/calendar")
+        cal.store.import_one("event.ics", "text/calendar", [body])
+
+    def _outbox(self):
+        # SingleUserFilesystemBackend does not autocreate the outbox in
+        # principal defaults, so create one explicitly here.
+        from xandikos.store import STORE_TYPE_SCHEDULE_OUTBOX
+
+        outbox_path = "/user/outbox"
+        if self.backend.get_resource(outbox_path) is None:
+            outbox_resource = self.backend.create_collection(outbox_path)
+            outbox_resource.store.set_type(STORE_TYPE_SCHEDULE_OUTBOX)
+        return self.backend.get_resource(outbox_path)
+
+    def test_returns_none_for_unknown_attendee(self):
+        outbox = self._outbox()
+        from datetime import datetime, timezone
+
+        start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 6, 2, tzinfo=timezone.utc)
+        result = asyncio.run(
+            outbox.get_attendee_busy_periods("mailto:stranger@example.com", start, end)
+        )
+        self.assertIsNone(result)
+
+    def test_returns_periods_for_principal_address(self):
+        from datetime import datetime, timezone
+
+        self._put_event(
+            b"BEGIN:VCALENDAR\r\n"
+            b"VERSION:2.0\r\n"
+            b"PRODID:-//Test//EN\r\n"
+            b"BEGIN:VEVENT\r\n"
+            b"UID:e1@example.com\r\n"
+            b"DTSTAMP:20260101T000000Z\r\n"
+            b"DTSTART:20260601T100000Z\r\n"
+            b"DTEND:20260601T110000Z\r\n"
+            b"SUMMARY:Standup\r\n"
+            b"END:VEVENT\r\n"
+            b"END:VCALENDAR\r\n"
+        )
+        outbox = self._outbox()
+        start = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 6, 2, tzinfo=timezone.utc)
+        result = asyncio.run(
+            outbox.get_attendee_busy_periods("mailto:user@example.com", start, end)
+        )
+        self.assertIsNotNone(result)
+        ical = b",".join(p.to_ical() for p in result).decode()
+        self.assertIn("20260601T100000Z/20260601T110000Z", ical)

--- a/xandikos/scheduling.py
+++ b/xandikos/scheduling.py
@@ -22,16 +22,38 @@
 See https://tools.ietf.org/html/rfc6638
 """
 
+import datetime
 import hashlib
+from collections.abc import Iterable
+from xml.etree import ElementTree as ET
 
-from icalendar.cal import Calendar
+from icalendar.cal import Calendar, Component, FreeBusy
+from icalendar.prop import vDDDTypes, vPeriod
 
 from xandikos import caldav, webdav
 from xandikos.caldav import (
+    PRODID,
     SCHEDULE_INBOX_RESOURCE_TYPE,
     SCHEDULE_OUTBOX_RESOURCE_TYPE,
 )
 from xandikos.icalendar import PropTypes
+
+
+# RFC 5546 §3.6 / RFC 6638 §6.2 request-status codes used in
+# schedule-response replies.
+REQUEST_STATUS_SUCCESS = "2.0;Success"
+REQUEST_STATUS_INVALID_CALENDAR_USER = "3.7;Invalid calendar user"
+REQUEST_STATUS_NO_AUTHORITY = "3.8;No authority"
+REQUEST_STATUS_SERVICE_UNAVAILABLE = "5.0;Service unavailable"
+
+
+class InvalidSchedulingRequest(Exception):
+    """The body submitted to the schedule-outbox is not a valid request."""
+
+    def __init__(self, description: str) -> None:
+        super().__init__(description)
+        self.description = description
+
 
 # Feature to advertise to indicate scheduling support.
 FEATURE = "calendar-auto-schedule"
@@ -268,6 +290,172 @@ class ScheduleOutbox(webdav.Collection):
     def get_max_attendees_per_instance(self):
         """Return maximum number of attendees per instance."""
         raise NotImplementedError(self.get_max_attendees_per_instance)
+
+    async def get_attendee_busy_periods(
+        self,
+        attendee_address: str,
+        start: datetime.datetime,
+        end: datetime.datetime,
+    ) -> Iterable[vPeriod] | None:
+        """Look up busy periods for *attendee_address* over [start, end).
+
+        Returns ``None`` if the server has no authority to answer for the
+        given attendee — that is the cue to emit a 3.7/3.8 status in the
+        schedule-response. The default implementation returns ``None`` for
+        all attendees; concrete servers override this to walk the
+        principal's calendar collections (or query a remote server).
+        """
+        return None
+
+    async def handle_post(
+        self,
+        request,
+        environ,
+        path: str,
+        body: list[bytes],
+        content_type: str,
+    ) -> "webdav.Response":
+        """Handle a POST to the schedule-outbox per RFC 6638 §6."""
+        if content_type != "text/calendar":
+            return webdav.Response(
+                status=415,
+                reason="Unsupported Media Type",
+                body=[b"Expected text/calendar"],
+            )
+        raw = b"".join(body).decode("utf-8")
+        try:
+            cal = Calendar.from_ical(raw)
+        except ValueError as exc:
+            raise webdav.BadRequestError(f"Invalid iCalendar: {exc}") from exc
+        try:
+            request_comp = _validate_freebusy_request(cal)
+        except InvalidSchedulingRequest as exc:
+            raise webdav.BadRequestError(exc.description) from exc
+
+        start, end = _parse_freebusy_window(request_comp)
+
+        organizer = request_comp.get("ORGANIZER")
+        attendees = request_comp.get("ATTENDEE", [])
+        if not isinstance(attendees, list):
+            attendees = [attendees]
+
+        responses: list[ET.Element] = []
+        for attendee in attendees:
+            recipient = str(attendee)
+            periods = await self.get_attendee_busy_periods(recipient, start, end)
+            if periods is None:
+                responses.append(
+                    _build_response_element(
+                        recipient, REQUEST_STATUS_NO_AUTHORITY, None
+                    )
+                )
+                continue
+            reply = _build_freebusy_reply(
+                organizer, recipient, request_comp, start, end, list(periods)
+            )
+            responses.append(
+                _build_response_element(
+                    recipient, REQUEST_STATUS_SUCCESS, reply.to_ical()
+                )
+            )
+
+        root = ET.Element("{%s}schedule-response" % caldav.NAMESPACE)
+        for r in responses:
+            root.append(r)
+        body_bytes = ET.tostring(root, encoding="utf-8")
+        return webdav.Response(
+            status=200,
+            reason="OK",
+            body=[body_bytes],
+            headers={"Content-Type": "application/xml; charset=utf-8"},
+        )
+
+
+def _validate_freebusy_request(cal: Component) -> Component:
+    """Return the single VFREEBUSY in *cal* if the request is well formed."""
+    method = cal.get("METHOD")
+    if str(method).upper() != "REQUEST":
+        raise InvalidSchedulingRequest(
+            "Schedule-outbox requests require METHOD:REQUEST"
+        )
+    fbs = [c for c in cal.subcomponents if c.name == "VFREEBUSY"]
+    others = [
+        c.name for c in cal.subcomponents if c.name not in ("VFREEBUSY", "VTIMEZONE")
+    ]
+    if others:
+        raise InvalidSchedulingRequest(
+            f"Free-busy request must contain only VFREEBUSY, got {others!r}"
+        )
+    if len(fbs) != 1:
+        raise InvalidSchedulingRequest(
+            f"Free-busy request must contain exactly one VFREEBUSY, got {len(fbs)}"
+        )
+    fb = fbs[0]
+    if "ORGANIZER" not in fb:
+        raise InvalidSchedulingRequest("VFREEBUSY missing ORGANIZER")
+    if "ATTENDEE" not in fb:
+        raise InvalidSchedulingRequest("VFREEBUSY missing ATTENDEE")
+    if "DTSTART" not in fb or "DTEND" not in fb:
+        raise InvalidSchedulingRequest("VFREEBUSY missing DTSTART/DTEND")
+    return fb
+
+
+def _parse_freebusy_window(
+    fb: Component,
+) -> tuple[datetime.datetime, datetime.datetime]:
+    start = fb["DTSTART"].dt
+    end = fb["DTEND"].dt
+    if isinstance(start, datetime.date) and not isinstance(start, datetime.datetime):
+        start = datetime.datetime.combine(start, datetime.time(), datetime.timezone.utc)
+    if isinstance(end, datetime.date) and not isinstance(end, datetime.datetime):
+        end = datetime.datetime.combine(end, datetime.time(), datetime.timezone.utc)
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=datetime.timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=datetime.timezone.utc)
+    return start, end
+
+
+def _build_freebusy_reply(
+    organizer,
+    recipient: str,
+    request_comp: Component,
+    start: datetime.datetime,
+    end: datetime.datetime,
+    periods: list[vPeriod],
+) -> Calendar:
+    """Build a METHOD:REPLY VCALENDAR with the per-recipient VFREEBUSY."""
+    cal = Calendar()
+    cal["VERSION"] = "2.0"
+    cal["PRODID"] = PRODID
+    cal["METHOD"] = "REPLY"
+    fb = FreeBusy()
+    fb["DTSTAMP"] = vDDDTypes(datetime.datetime.now(datetime.timezone.utc))
+    fb["DTSTART"] = vDDDTypes(start)
+    fb["DTEND"] = vDDDTypes(end)
+    if organizer is not None:
+        fb["ORGANIZER"] = organizer
+    fb["ATTENDEE"] = recipient
+    if "UID" in request_comp:
+        fb["UID"] = request_comp["UID"]
+    if periods:
+        fb["FREEBUSY"] = periods
+    cal.add_component(fb)
+    return cal
+
+
+def _build_response_element(
+    recipient: str, request_status: str, calendar_data: bytes | None
+) -> ET.Element:
+    el = ET.Element("{%s}response" % caldav.NAMESPACE)
+    rec = ET.SubElement(el, "{%s}recipient" % caldav.NAMESPACE)
+    rec.append(webdav.create_href(recipient))
+    status = ET.SubElement(el, "{%s}request-status" % caldav.NAMESPACE)
+    status.text = request_status
+    if calendar_data is not None:
+        cd = ET.SubElement(el, "{%s}calendar-data" % caldav.NAMESPACE)
+        cd.text = calendar_data.decode("utf-8")
+    return el
 
 
 class ScheduleInboxURLProperty(webdav.Property):

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -427,20 +427,21 @@ class StoreBasedCollection:
 
     async def create_member(
         self,
-        name: str,
+        name: str | None,
         contents: Iterable[bytes],
         content_type: str,
         remote_user: str | None = None,
         requester: str | None = None,
     ) -> tuple[str, str]:
         # Check if member already exists and raise FileExistsError if it does
-        try:
-            existing_member = self.get_member(name)
-            if existing_member is not None:
-                raise FileExistsError(f"Member '{name}' already exists")
-        except KeyError:
-            # Member doesn't exist, which is what we want for create_member
-            pass
+        if name is not None:
+            try:
+                existing_member = self.get_member(name)
+                if existing_member is not None:
+                    raise FileExistsError(f"Member '{name}' already exists")
+            except KeyError:
+                # Member doesn't exist, which is what we want for create_member
+                pass
 
         try:
             (name, etag) = self.store.import_one(
@@ -570,6 +571,45 @@ class ScheduleInbox(StoreBasedCollection, scheduling.ScheduleInbox):
 
 class ScheduleOutbox(StoreBasedCollection, scheduling.ScheduleOutbox):
     """A schedling outbox collection."""
+
+    async def get_attendee_busy_periods(self, attendee_address, start, end):
+        """Look up busy periods for *attendee_address* within [start, end).
+
+        Returns ``None`` if the address does not belong to this outbox's
+        principal — that is, the server has no authority to answer for
+        this attendee. Otherwise walks the principal's calendar-home and
+        gathers busy/availability periods via :func:`caldav.iter_freebusy`.
+        """
+        principal_path = posixpath.dirname(self.relpath.rstrip("/"))
+        principal = self.backend.get_principal(principal_path)
+        if principal is None:
+            return None
+        if attendee_address not in principal.get_calendar_user_address_set():
+            return None
+
+        from zoneinfo import ZoneInfo
+
+        utc = ZoneInfo("UTC")
+
+        def tzify(dt):
+            from .icalendar import as_tz_aware_ts
+
+            return as_tz_aware_ts(dt, utc).astimezone(utc)
+
+        periods = []
+        for home in principal.get_calendar_home_set():
+            home_path = posixpath.join(principal_path, home)
+            home_resource = self.backend.get_resource(home_path)
+            if home_resource is None:
+                continue
+            async for period in caldav.iter_freebusy(
+                webdav.traverse_resource(home_resource, home_path, "infinity"),
+                start,
+                end,
+                tzify,
+            ):
+                periods.append(period)
+        return periods
 
 
 class SubscriptionCollection(StoreBasedCollection, caldav.Subscription):
@@ -1205,6 +1245,17 @@ class SingleUserFilesystemBackend(FilesystemBackend):
     def find_principals(self):
         """List all of the principals on this server."""
         return self._user_principals
+
+    def get_principal(self, relpath: str) -> "Principal | None":
+        relpath = posixpath.normpath(relpath)
+        if relpath not in self._user_principals:
+            return None
+        # Defer to the regular get_resource path so the lookup picks up
+        # whichever Principal subclass corresponds to the on-disk layout.
+        r = self.get_resource(relpath)
+        if isinstance(r, Principal):
+            return r
+        return None
 
     def get_resource(self, relpath):
         relpath = posixpath.normpath(relpath)

--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -1036,7 +1036,7 @@ class Collection(Resource):
 
     async def create_member(
         self,
-        name: str,
+        name: str | None,
         contents: Iterable[bytes],
         content_type: str,
         remote_user: str | None = None,
@@ -1045,7 +1045,7 @@ class Collection(Resource):
         """Create a new member with specified name and contents.
 
         Args:
-          name: Member name (can be None)
+          name: Member name; ``None`` lets the implementation pick one.
           contents: Chunked contents
           content_type: Content type of the member
           remote_user: Optional user name of the actor
@@ -1053,6 +1053,55 @@ class Collection(Resource):
         Returns: (name, etag) for the new member
         """
         raise NotImplementedError(self.create_member)
+
+    async def handle_post(
+        self,
+        request,
+        environ,
+        path: str,
+        body: list[bytes],
+        content_type: str,
+    ) -> "Response":
+        """Handle a POST request targeted at this collection.
+
+        The default implementation interprets the request as an
+        RFC 5995 add-member request. Subclasses may override this
+        to provide collection-specific POST semantics — for example
+        a CalDAV schedule-outbox processes free-busy lookups here
+        (RFC 6638 §6).
+
+        Args:
+          request: incoming request object
+          environ: WSGI environ
+          path: collection path the request was directed at
+          body: request body, already read
+          content_type: parsed content type (without parameters)
+
+        Returns: a Response.
+        """
+        try:
+            (name, etag) = await self.create_member(
+                None,
+                body,
+                content_type,
+                remote_user=environ.get("REMOTE_USER"),
+                requester=request.headers.get("User-Agent"),
+            )
+        except PreconditionFailure as e:
+            return _send_simple_dav_error(
+                request,
+                "412 Precondition Failed",
+                error=ET.Element(e.precondition),
+                description=e.description,
+            )
+        except InsufficientStorage:
+            return Response(status=507, reason="Insufficient Storage")
+        except ResourceLocked:
+            return Response(status=423, reason="Resource Locked")
+        href = environ["SCRIPT_NAME"] + urllib.parse.urljoin(
+            ensure_trailing_slash(path), urllib.parse.quote(name)
+        )
+        return Response(headers={"Location": href})
 
     async def move_member(
         self,
@@ -1735,6 +1784,18 @@ class Backend:
     def get_resource(self, relpath: str) -> Resource | None:
         raise NotImplementedError(self.get_resource)
 
+    def get_principal(self, relpath: str) -> "Principal | None":
+        """Return the principal at *relpath*, or None if it isn't one.
+
+        Subclasses with their own principal bookkeeping may override this
+        for efficiency. The default implementation defers to
+        :meth:`get_resource` and narrows the result.
+        """
+        r = self.get_resource(relpath)
+        if isinstance(r, Principal):
+            return r
+        return None
+
     def get_resources(self, relpaths) -> Iterator[tuple[str, Resource | None]]:
         for relpath in relpaths:
             yield relpath, self.get_resource(relpath)
@@ -2022,7 +2083,6 @@ class PostMethod(Method):
         return COLLECTION_RESOURCE_TYPE in r.resource_types
 
     async def handle(self, request, environ, app):
-        # see RFC5995
         new_contents = await _readBody(request)
         unused_href, path, r = app._get_resource_from_environ(request, environ)
         if r is None:
@@ -2032,29 +2092,7 @@ class PostMethod(Method):
                 await app._get_allowed_methods(request, environ)
             )
         content_type, params = parse_type(request.content_type)
-        try:
-            (name, etag) = await r.create_member(
-                None,
-                new_contents,
-                content_type,
-                remote_user=environ.get("REMOTE_USER"),
-                requester=request.headers.get("User-Agent"),
-            )
-        except PreconditionFailure as e:
-            return _send_simple_dav_error(
-                request,
-                "412 Precondition Failed",
-                error=ET.Element(e.precondition),
-                description=e.description,
-            )
-        except InsufficientStorage:
-            return Response(status=507, reason="Insufficient Storage")
-        except ResourceLocked:
-            return Response(status=423, reason="Resource Locked")
-        href = environ["SCRIPT_NAME"] + urllib.parse.urljoin(
-            ensure_trailing_slash(path), urllib.parse.quote(name)
-        )
-        return Response(headers={"Location": href})
+        return await r.handle_post(request, environ, path, new_contents, content_type)
 
 
 class PutMethod(Method):


### PR DESCRIPTION
POSTing METHOD:REQUEST + VFREEBUSY against a schedule-outbox now returns the per-attendee schedule-response XML described in RFC 6638 §6, with a "2.0;Success" iTIP REPLY for addresses the server has authority over and "3.8;No authority" for the rest.

The outbox dispatch goes through a new Collection.handle_post hook so webdav.PostMethod stays free of CalDAV-specific knowledge; the default still does RFC 5995 add-member. Per-attendee free-busy lookup is itself a hook on ScheduleOutbox; the concrete implementation in xandikos.web aggregates over the principal's calendar-home via caldav.iter_freebusy.

Adds Backend.get_principal so callers don't have to read back from get_resource and isinstance-check the result. Also widens Collection.create_member's name parameter to str | None to match how PostMethod has always invoked it.