### PR TITLE
scheduling: Wire schedule-default-calendar-URL on the inbox

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1240,3 +1240,50 @@ class CalendarCollectionPrePutHookAttendeeReplyTests(unittest.TestCase):
         self._put(accepted)
         # Alice is unaffected.
         self.assertEqual([], self._inbox_messages("/alice"))
+
+
+class ScheduleInboxDefaultCalendarTests(unittest.TestCase):
+    """Tests for ScheduleInbox.get_schedule_default_calendar_url (RFC 6638 §9.2)."""
+
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir)
+        self.backend = SingleUserFilesystemBackend(self.tempdir)
+
+    def _inbox(self, principal: str = "/alice"):
+        from xandikos.web import ScheduleInbox
+
+        inbox = self.backend.get_resource(f"{principal}/inbox")
+        assert isinstance(inbox, ScheduleInbox)
+        return inbox
+
+    def test_returns_default_calendar_when_one_exists(self):
+        self.backend.create_principal("/alice", create_defaults=True)
+        url = self._inbox().get_schedule_default_calendar_url()
+        self.assertEqual("/alice/calendars/calendar", url)
+
+    def test_returns_none_when_no_calendars(self):
+        # Create just the principal + inbox; no calendar collections.
+        self.backend.create_principal("/alice")
+        self.backend.create_collection("/alice/inbox")
+        from xandikos.store import STORE_TYPE_SCHEDULE_INBOX
+
+        inbox_resource = self.backend.get_resource("/alice/inbox")
+        assert isinstance(inbox_resource, StoreBasedCollection)
+        inbox_resource.store.set_type(STORE_TYPE_SCHEDULE_INBOX)
+        # Refetch so the type-dispatch picks ScheduleInbox.
+        self.assertIsNone(self._inbox().get_schedule_default_calendar_url())
+
+    def test_picks_first_calendar_when_multiple(self):
+        from xandikos.store import STORE_TYPE_CALENDAR
+
+        self.backend.create_principal("/alice", create_defaults=True)
+        # create_defaults already made /alice/calendars/calendar; add a second.
+        extra = self.backend.create_collection("/alice/calendars/work")
+        extra.store.set_type(STORE_TYPE_CALENDAR)
+
+        url = self._inbox().get_schedule_default_calendar_url()
+        # The directory listing isn't ordered, but the result must point at
+        # one of the two calendars — not nothing, not something else.
+        self.assertIn(url, {"/alice/calendars/calendar", "/alice/calendars/work"})

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -569,6 +569,30 @@ class Collection(StoreBasedCollection, webdav.Collection):
 class ScheduleInbox(StoreBasedCollection, scheduling.ScheduleInbox):
     """A schedling inbox collection."""
 
+    def get_schedule_default_calendar_url(self) -> str | None:
+        """Pick a default calendar in the owning principal's calendar-home.
+
+        RFC 6638 §9.2 lets an inbox advertise a single calendar where
+        clients should look (and where scheduling deliveries land) by
+        default. Without per-principal configuration we just pick the
+        first calendar resource found by walking each calendar-home
+        the principal advertises, in order. Returns ``None`` if the
+        principal has no calendars yet.
+        """
+        owning = scheduling.find_owning_principal(self.backend, self.relpath)
+        if owning is None:
+            return None
+        principal_path, principal = owning
+        for home in principal.get_calendar_home_set():
+            home_path = posixpath.join(principal_path, home)
+            home_resource = self.backend.get_resource(home_path)
+            if home_resource is None:
+                continue
+            for name, member in home_resource.members():
+                if caldav.CALENDAR_RESOURCE_TYPE in member.resource_types:
+                    return posixpath.join(home_path, name)
+        return None
+
 
 class ScheduleOutbox(StoreBasedCollection, scheduling.ScheduleOutbox):
     """A schedling outbox collection."""


### PR DESCRIPTION
The property class for schedule-default-calendar-URL has existed for a while but always emitted nothing — ScheduleInbox returned None. So clients reading the inbox saw the property advertised but empty, giving them no way to discover where to default new scheduling objects to (RFC 6638 §9.2).