### PR TITLE
scheduling: Auto-apply iTIP messages to recipient's default calendar

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1346,3 +1346,224 @@ class ScheduleInboxDefaultCalendarTests(unittest.TestCase):
         # The directory listing isn't ordered, but the result must point at
         # one of the two calendars — not nothing, not something else.
         self.assertIn(url, {"/alice/calendars/calendar", "/alice/calendars/work"})
+
+
+class InboxAutoProcessingTests(unittest.TestCase):
+    """End-to-end tests for RFC 6638 §3.1 implicit-scheduling.
+
+    Verifies that iTIP messages delivered to an inbox don't just sit
+    there — they get auto-applied to the recipient's default calendar:
+    REQUEST creates a tentative copy, CANCEL marks the existing one
+    cancelled, REPLY updates the organiser's stored copy.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir)
+        self.backend = SingleUserFilesystemBackend(self.tempdir)
+        self.backend.create_principal("/alice", create_defaults=True)
+        self.backend.create_principal("/bob", create_defaults=True)
+
+        self._addresses = {
+            "/alice": ["mailto:alice@example.com"],
+            "/bob": ["mailto:bob@example.com"],
+        }
+        from xandikos.web import Principal
+
+        original = Principal.get_calendar_user_address_set
+        addresses = self._addresses
+
+        def fake_addresses(principal_self):
+            return addresses.get(principal_self.relpath, [])
+
+        Principal.get_calendar_user_address_set = fake_addresses
+        self.addCleanup(setattr, Principal, "get_calendar_user_address_set", original)
+
+    def _alice_calendar(self) -> CalendarCollection:
+        cal = self.backend.get_resource("/alice/calendars/calendar")
+        assert isinstance(cal, CalendarCollection)
+        return cal
+
+    def _bob_calendar(self) -> CalendarCollection:
+        cal = self.backend.get_resource("/bob/calendars/calendar")
+        assert isinstance(cal, CalendarCollection)
+        return cal
+
+    def _calendar_events(self, principal: str) -> list[dict]:
+        """Return parsed VEVENTs from the principal's default calendar.
+
+        Each entry is a dict of the iTIP-relevant fields, suitable for
+        exact ``assertEqual`` comparison without depending on the raw
+        iCalendar serialization (DTSTAMP, line ordering, etc.).
+        """
+        from icalendar.cal import Calendar as ICalendar
+
+        cal = self.backend.get_resource(f"{principal}/calendars/calendar")
+        assert isinstance(cal, StoreBasedCollection)
+        store = cal.store
+        events: list[dict] = []
+        for name, _ct, etag in store.iter_with_etag():
+            raw = b"".join(store._get_raw(name, etag))
+            parsed = ICalendar.from_ical(raw.decode("utf-8"))
+            method = parsed.get("METHOD")
+            for comp in parsed.subcomponents:
+                if comp.name != "VEVENT":
+                    continue
+                attendees = comp.get("ATTENDEE", [])
+                if not isinstance(attendees, list):
+                    attendees = [attendees]
+                events.append(
+                    {
+                        "uid": str(comp["UID"]),
+                        "method": str(method) if method is not None else None,
+                        "status": str(comp["STATUS"]) if "STATUS" in comp else None,
+                        "summary": str(comp["SUMMARY"]) if "SUMMARY" in comp else None,
+                        "organizer": str(comp["ORGANIZER"])
+                        if "ORGANIZER" in comp
+                        else None,
+                        "attendees": {
+                            str(a): str(a.params.get("PARTSTAT", "NEEDS-ACTION"))
+                            for a in attendees
+                        },
+                    }
+                )
+        return events
+
+    INVITATION = (
+        b"BEGIN:VCALENDAR\r\n"
+        b"VERSION:2.0\r\n"
+        b"PRODID:-//Test//EN\r\n"
+        b"BEGIN:VEVENT\r\n"
+        b"UID:meet@example.com\r\n"
+        b"DTSTAMP:20260101T120000Z\r\n"
+        b"SEQUENCE:1\r\n"
+        b"DTSTART:20260601T100000Z\r\n"
+        b"DTEND:20260601T110000Z\r\n"
+        b"SUMMARY:Sync\r\n"
+        b"ORGANIZER:mailto:alice@example.com\r\n"
+        b"ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com\r\n"
+        b"END:VEVENT\r\n"
+        b"END:VCALENDAR\r\n"
+    )
+
+    def test_request_creates_tentative_copy_in_attendee_calendar(self):
+        # Alice PUTs a new event with bob as attendee. Bob should now see
+        # the event in his own calendar, not just his inbox.
+        asyncio.run(
+            self._alice_calendar().pre_put_hook(
+                "event.ics", [self.INVITATION], "text/calendar"
+            )
+        )
+        self.assertEqual(
+            [
+                {
+                    "uid": "meet@example.com",
+                    # Stored calendar objects don't carry METHOD — that's an
+                    # iTIP transport property, not stored alongside events
+                    # (RFC 5545 §3.4).
+                    "method": None,
+                    "status": None,
+                    "summary": "Sync",
+                    "organizer": "mailto:alice@example.com",
+                    "attendees": {"mailto:bob@example.com": "NEEDS-ACTION"},
+                }
+            ],
+            self._calendar_events("/bob"),
+        )
+
+    def test_request_resend_preserves_attendee_partstat(self):
+        # Bob has accepted alice's invitation in his calendar.
+        accepted = self.INVITATION.replace(
+            b"PARTSTAT=NEEDS-ACTION", b"PARTSTAT=ACCEPTED"
+        )
+        self._bob_calendar().store.import_one("event.ics", "text/calendar", [accepted])
+        # Alice now resends a REQUEST (typical: she edits the event).
+        edited = self.INVITATION.replace(b"SUMMARY:Sync", b"SUMMARY:Sync (rev)")
+        asyncio.run(
+            self._alice_calendar().pre_put_hook("event.ics", [edited], "text/calendar")
+        )
+        # Bob's calendar copy now has the updated SUMMARY, but his
+        # PARTSTAT is preserved.
+        self.assertEqual(
+            [
+                {
+                    "uid": "meet@example.com",
+                    "method": None,
+                    "status": None,
+                    "summary": "Sync (rev)",
+                    "organizer": "mailto:alice@example.com",
+                    "attendees": {"mailto:bob@example.com": "ACCEPTED"},
+                }
+            ],
+            self._calendar_events("/bob"),
+        )
+
+    def test_cancel_marks_attendee_copy_cancelled(self):
+        # Bob has accepted alice's invitation.
+        self._bob_calendar().store.import_one(
+            "event.ics", "text/calendar", [self.INVITATION]
+        )
+        # Alice deletes the event in her calendar — sends CANCEL.
+        self._alice_calendar().store.import_one(
+            "event.ics", "text/calendar", [self.INVITATION]
+        )
+        asyncio.run(self._alice_calendar().pre_delete_hook("event.ics"))
+
+        # The event is still there but marked cancelled; bob's client
+        # decides whether to hide or surface it.
+        self.assertEqual(
+            [
+                {
+                    "uid": "meet@example.com",
+                    "method": None,
+                    "status": "CANCELLED",
+                    "summary": "Sync",
+                    "organizer": "mailto:alice@example.com",
+                    "attendees": {"mailto:bob@example.com": "NEEDS-ACTION"},
+                }
+            ],
+            self._calendar_events("/bob"),
+        )
+
+    def test_reply_updates_organiser_calendar_partstat(self):
+        # Alice has the original event in her calendar.
+        self._alice_calendar().store.import_one(
+            "event.ics", "text/calendar", [self.INVITATION]
+        )
+        # Bob has his copy too, will accept it.
+        self._bob_calendar().store.import_one(
+            "event.ics", "text/calendar", [self.INVITATION]
+        )
+        accepted = self.INVITATION.replace(
+            b"PARTSTAT=NEEDS-ACTION", b"PARTSTAT=ACCEPTED"
+        )
+        # Bob PUTs the accepted version: triggers REPLY → alice's inbox →
+        # auto-processing should update bob's PARTSTAT in alice's stored copy.
+        asyncio.run(
+            self._bob_calendar().pre_put_hook("event.ics", [accepted], "text/calendar")
+        )
+        self.assertEqual(
+            [
+                {
+                    "uid": "meet@example.com",
+                    "method": None,
+                    "status": None,
+                    "summary": "Sync",
+                    "organizer": "mailto:alice@example.com",
+                    "attendees": {"mailto:bob@example.com": "ACCEPTED"},
+                }
+            ],
+            self._calendar_events("/alice"),
+        )
+
+    def test_cancel_with_no_existing_copy_is_noop(self):
+        # Bob never had alice's event — CANCEL arrives anyway. Nothing
+        # to cancel locally; inbox copy still records what happened.
+        self._alice_calendar().store.import_one(
+            "event.ics", "text/calendar", [self.INVITATION]
+        )
+        # Alice deletes; CANCEL goes to bob.
+        asyncio.run(self._alice_calendar().pre_delete_hook("event.ics"))
+        # Bob's calendar is empty (no auto-create on CANCEL).
+        self.assertEqual([], self._calendar_events("/bob"))

--- a/xandikos/itip.py
+++ b/xandikos/itip.py
@@ -394,3 +394,67 @@ async def deliver_to_inbox(
     body = itip_message.to_ical()
     await inbox.create_member(name_hint, [body], "text/calendar")
     return True
+
+
+def itip_uid(itip_message: Calendar) -> str | None:
+    """Return the UID of the first scheduling component in *itip_message*."""
+    for comp in itip_message.subcomponents:
+        if comp.name in SCHEDULING_COMPONENTS:
+            uid = comp.get("UID")
+            if uid is not None:
+                return str(uid)
+    return None
+
+
+def strip_method(itip_message: Calendar) -> Calendar:
+    """Return a copy of *itip_message* with METHOD removed.
+
+    Stored calendar objects don't carry METHOD — that's a property of
+    iTIP transport messages, not the events themselves (RFC 5545
+    §3.4 / RFC 6638 §3.1).
+    """
+    out = Calendar()
+    for k, v in itip_message.items():
+        if k.upper() == "METHOD":
+            continue
+        out[k] = v
+    for comp in itip_message.subcomponents:
+        out.add_component(comp.copy())
+    return out
+
+
+def preserve_partstats(existing: Calendar, incoming: Calendar) -> Calendar:
+    """Mutate *incoming* in place so attendee PARTSTATs survive a re-REQUEST.
+
+    RFC 6638 §3.2.1: when an organiser sends a fresh REQUEST, the
+    attendee's prior PARTSTAT must survive. We match attendees across
+    components by (UID, RECURRENCE-ID, ATTENDEE address). Returns the
+    same *incoming* object for chaining.
+    """
+    existing_partstats: dict[tuple[str, str, str], str] = {}
+    for comp in existing.subcomponents:
+        if comp.name not in SCHEDULING_COMPONENTS:
+            continue
+        uid = str(comp.get("UID", ""))
+        rid = str(comp.get("RECURRENCE-ID", ""))
+        attendees = comp.get("ATTENDEE", [])
+        if not isinstance(attendees, list):
+            attendees = [attendees]
+        for a in attendees:
+            partstat = a.params.get("PARTSTAT")
+            if partstat is not None:
+                existing_partstats[(uid, rid, str(a))] = str(partstat)
+
+    for comp in incoming.subcomponents:
+        if comp.name not in SCHEDULING_COMPONENTS:
+            continue
+        uid = str(comp.get("UID", ""))
+        rid = str(comp.get("RECURRENCE-ID", ""))
+        attendees = comp.get("ATTENDEE", [])
+        if not isinstance(attendees, list):
+            attendees = [attendees]
+        for a in attendees:
+            prior = existing_partstats.get((uid, rid, str(a)))
+            if prior is not None:
+                a.params["PARTSTAT"] = prior
+    return incoming

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -463,7 +463,24 @@ class StoreBasedCollection:
             raise webdav.InsufficientStorage() from exc
         except LockedError as exc:
             raise webdav.ResourceLocked() from exc
+        await self.post_create_member_hook(name, contents, content_type)
         return (name, create_strong_etag(etag))
+
+    async def post_create_member_hook(
+        self,
+        name: str,
+        contents: Iterable[bytes],
+        content_type: str,
+    ) -> None:
+        """Run side-effects just after a member has been created.
+
+        Default is a no-op. The schedule-inbox overrides this to
+        auto-apply incoming iTIP messages to the principal's default
+        calendar (RFC 6638 §3.1 implicit scheduling). Failures here
+        do not roll the create back; the stored item is the canonical
+        record and the auto-processing is best-effort.
+        """
+        return None
 
     def iter_differences_since(
         self, old_token: str, new_token: str
@@ -592,6 +609,181 @@ class ScheduleInbox(StoreBasedCollection, scheduling.ScheduleInbox):
                 if caldav.CALENDAR_RESOURCE_TYPE in member.resource_types:
                     return posixpath.join(home_path, name)
         return None
+
+    async def post_create_member_hook(
+        self,
+        name: str,
+        contents: Iterable[bytes],
+        content_type: str,
+    ) -> None:
+        """Auto-apply the just-stored iTIP message to the default calendar.
+
+        RFC 6638 §3.1: when an iTIP message lands in a principal's
+        schedule-inbox, the server should mirror its semantics into
+        the principal's own calendar so the user's CalDAV client sees
+        the state without having to read the inbox itself.
+
+        - REQUEST → upsert into the default calendar, preserving any
+          existing PARTSTAT on attendees we already know about.
+        - CANCEL → mark the matching local copy STATUS:CANCELLED.
+        - REPLY → update the sender's ATTENDEE PARTSTAT on the
+          organiser's stored copy.
+
+        The inbox copy itself is the canonical record of what
+        arrived; we don't roll it back if auto-processing fails. If
+        no default calendar is configured we silently skip — clients
+        can still find the message in the inbox.
+        """
+        if content_type != "text/calendar":
+            return
+        try:
+            parsed = Calendar.from_ical(b"".join(contents).decode("utf-8"))
+        except ValueError:
+            return
+        if not isinstance(parsed, Calendar):
+            return
+        method_value = parsed.get("METHOD")
+        method = str(method_value).upper() if method_value is not None else ""
+        if method not in {"REQUEST", "CANCEL", "REPLY"}:
+            return
+
+        calendar = self._default_calendar()
+        if calendar is None:
+            return
+        uid = itip.itip_uid(parsed)
+        if uid is None:
+            return
+        existing = await _find_calendar_member_by_uid(calendar, uid)
+
+        if method == "REQUEST":
+            await self._apply_request(calendar, parsed, existing)
+        elif method == "CANCEL":
+            await self._apply_cancel(parsed, uid, existing)
+        elif method == "REPLY":
+            await self._apply_reply(parsed, uid, existing)
+
+    def _default_calendar(self) -> "CalendarCollection | None":
+        url = self.get_schedule_default_calendar_url()
+        if url is None:
+            return None
+        cal = self.backend.get_resource(url)
+        if not isinstance(cal, CalendarCollection):
+            return None
+        return cal
+
+    async def _apply_request(
+        self,
+        calendar: "CalendarCollection",
+        itip_message: Calendar,
+        existing: "tuple[str, ObjectResource, Calendar] | None",
+    ) -> None:
+        new_cal = itip.strip_method(itip_message)
+        if existing is None:
+            await calendar.create_member(None, [new_cal.to_ical()], "text/calendar")
+            return
+        member_name, member, existing_cal = existing
+        merged = itip.preserve_partstats(existing_cal, new_cal)
+        await _replace_member_body(member, merged)
+
+    async def _apply_cancel(
+        self,
+        itip_message: Calendar,
+        uid: str,
+        existing: "tuple[str, ObjectResource, Calendar] | None",
+    ) -> None:
+        if existing is None:
+            return
+        member_name, member, existing_cal = existing
+        for comp in existing_cal.subcomponents:
+            if (
+                comp.name in itip.SCHEDULING_COMPONENTS
+                and str(comp.get("UID", "")) == uid
+            ):
+                comp["STATUS"] = "CANCELLED"
+        await _replace_member_body(member, existing_cal)
+
+    async def _apply_reply(
+        self,
+        itip_message: Calendar,
+        uid: str,
+        existing: "tuple[str, ObjectResource, Calendar] | None",
+    ) -> None:
+        if existing is None:
+            return
+        member_name, member, existing_cal = existing
+
+        # Pick out the replying attendee's address + new PARTSTAT.
+        updates: dict[str, str] = {}
+        for comp in itip_message.subcomponents:
+            if comp.name not in itip.SCHEDULING_COMPONENTS:
+                continue
+            if str(comp.get("UID", "")) != uid:
+                continue
+            attendees = comp.get("ATTENDEE", [])
+            if not isinstance(attendees, list):
+                attendees = [attendees]
+            for a in attendees:
+                partstat = a.params.get("PARTSTAT")
+                if partstat is not None:
+                    updates[str(a)] = str(partstat)
+        if not updates:
+            return
+
+        changed = False
+        for comp in existing_cal.subcomponents:
+            if comp.name not in itip.SCHEDULING_COMPONENTS:
+                continue
+            if str(comp.get("UID", "")) != uid:
+                continue
+            attendees = comp.get("ATTENDEE", [])
+            if not isinstance(attendees, list):
+                attendees = [attendees]
+            for a in attendees:
+                new_partstat = updates.get(str(a))
+                if (
+                    new_partstat is not None
+                    and a.params.get("PARTSTAT") != new_partstat
+                ):
+                    a.params["PARTSTAT"] = new_partstat
+                    changed = True
+        if changed:
+            await _replace_member_body(member, existing_cal)
+
+
+async def _find_calendar_member_by_uid(
+    calendar: "CalendarCollection", uid: str
+) -> "tuple[str, ObjectResource, Calendar] | None":
+    """Find a member of *calendar* whose VCALENDAR has an event with *uid*.
+
+    Returns ``(name, ObjectResource, parsed_calendar)`` or None. The
+    ObjectResource is returned alongside the parsed calendar so
+    callers can update it in place without re-resolving.
+    """
+    for name, member in calendar.members():
+        if not isinstance(member, ObjectResource):
+            continue
+        if member.get_content_type() != "text/calendar":
+            continue
+        file = await member.get_file()
+        if not isinstance(file, ICalendarFile):
+            continue
+        cal = file.calendar
+        if not isinstance(cal, Calendar):
+            continue
+        for comp in cal.subcomponents:
+            if (
+                comp.name in itip.SCHEDULING_COMPONENTS
+                and str(comp.get("UID", "")) == uid
+            ):
+                return name, member, cal
+    return None
+
+
+async def _replace_member_body(member: "ObjectResource", new_cal: Calendar) -> None:
+    """Replace *member*'s body with *new_cal*'s serialized bytes."""
+    body = new_cal.to_ical()
+    etag = await member.get_etag()
+    await member.set_body([body], replace_etag=etag)
 
 
 class ScheduleOutbox(StoreBasedCollection, scheduling.ScheduleOutbox):


### PR DESCRIPTION
RFC 6638 §3.1 implicit scheduling: when an iTIP message lands in a schedule-inbox, the server mirrors its semantics into the principal's own calendar so the user's CalDAV client sees the new state without having to read the inbox itself.

- REQUEST -> upsert the event into the default calendar (preserving any existing PARTSTAT on attendees we already know about, so a re-REQUEST after the user accepted doesn't reset them to NEEDS-ACTION)
- CANCEL -> mark the local copy STATUS:CANCELLED rather than deleting, so cancelled invites stay visible in the user's calendar
- REPLY -> update the sender's ATTENDEE PARTSTAT on the organiser's stored copy