### PR TITLE
fix: skip RRULE expansion for components without DTSTART

### DIFF
--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -1906,6 +1906,41 @@ END:VCALENDAR"""
                 f"RECURRENCE-ID {rid.dt} should be timezone-aware",
             )
 
+    def test_filter_vtodo_rrule_without_dtstart(self):
+        """CalendarFilter time-range check must not crash on VTODO with RRULE but no DTSTART.
+
+        RFC 5545 §3.6.2 makes DTSTART optional for VTODO.  A recurring VTODO
+        that only carries COMPLETED (and no DTSTART/DUE) would previously cause
+        a KeyError in _expand_rrule_component() when xandikos fell back to full
+        calendar expansion for time-range filtering.
+        """
+        test_ical = b"""BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VTODO
+UID:recurring-todo-no-dtstart@example.com
+COMPLETED:20231001T105204Z
+DTSTAMP:20231001T124832Z
+RRULE:FREQ=DAILY
+STATUS:COMPLETED
+SUMMARY:g\xc3\xa5 tur
+END:VTODO
+END:VCALENDAR"""
+
+        cal_file = ICalendarFile([test_ical], "text/calendar")
+        filter_obj = CalendarFilter(ZoneInfo("UTC"))
+        filter_obj.filter_subcomponent("VCALENDAR").filter_subcomponent(
+            "VTODO"
+        ).filter_time_range(
+            start=datetime(2026, 5, 14, tzinfo=timezone.utc),
+            end=datetime(2026, 5, 21, tzinfo=timezone.utc),
+        )
+        # Must not raise KeyError on DTSTART; result may be True or False
+        # (xandikos can't expand without DTSTART, so it treats the task as
+        # timeless and the filter falls through to the file-level check)
+        result = filter_obj.check("test.ics", cal_file)
+        self.assertIsInstance(result, bool)
+
 
 class MixedDateDatetimeTests(unittest.TestCase):
     """Test handling of mixed date/datetime types in EXDATE/RDATE.

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -1964,6 +1964,9 @@ def _expand_rrule_component(
 ) -> Iterable[Component]:
     if "RRULE" not in incomp:
         return
+    if "DTSTART" not in incomp:
+        # RFC 5545 makes DTSTART optional for VTODO; can't expand without it.
+        return
 
     rs = rruleset_from_comp(incomp)
     original_dtstart = incomp["DTSTART"]

--- a/xandikos/store/git.py
+++ b/xandikos/store/git.py
@@ -794,7 +794,7 @@ class BareGitStore(GitStore):
         Returns: etag
         """
         b = Blob()
-        b.chunked = data
+        b.chunked = list(data)
         tree = self._get_current_tree()
         old_tree_id = tree.id
         name_enc = name.encode(DEFAULT_ENCODING)


### PR DESCRIPTION
I'm trying to load a backup of a calendar into xandikos, but it
appears some of the backup data is slightly broken, which again causes
various errors from Xandikos.  The most broken things I'm discarding
or editing, but Claude considered the case "VTODO with RRULE but
without DTSTART" was worthy an upstream fix, because RFC 5545 §3.6.2
makes DTSTART optional for VTODO.

Arguably Xandikos should never be crashing with 500 - it could for
instance yield 400 when trying to save broken icalendar data rather
than crashing later on when trying to take out REPORTs.  please
indicate if you want a full report of broken things causing Xandikos
to break down.  The previous problem was a lone recurrence exception
with a RECURRENCE-ID, but with no "parent" with same UID and RRULE
set.

Feel free to close this pull request rapidly even without a comment if
you find it OK to yield a 500 internal server error on this one.  I
won't send more such silly pull requests in that case :-)
