### PR TITLE
Allow per-principal calendar/addressbook-home-set overrides

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,10 @@
    collection URL to get one merged ``.ics`` file suitable for consumers
    such as Google Calendar's "Add by URL". (Jelmer Vernooĳ, #164)
 
+ * Allow per-principal calendar-home-set and addressbook-home-set overrides
+   via the ``[principal]`` section of the principal's ``.xandikos`` config.
+   (Jelmer Vernooĳ, #17)
+
 0.4.0	2026-05-09
 
  * Support scheduling (iTIP/iMIP). (Jelmer Vernooĳ)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -201,6 +201,27 @@ Create ``/etc/systemd/system/xandikos.service``:
    [Install]
    WantedBy=multi-user.target
 
+Per-Principal Configuration
+---------------------------
+
+A principal's settings live in a ``.xandikos`` INI file directly under
+the principal directory. The same file holds scheduling settings such as
+``calendar-user-address-set`` and the calendar/addressbook home-set
+overrides.
+
+To advertise calendar and addressbook home collections at non-default
+paths for a principal, drop a ``.xandikos`` file under the principal
+directory before the home directories are created:
+
+.. code-block:: ini
+
+   [principal]
+   calendar-home-set = my-calendars
+   addressbook-home-set = my-contacts
+
+Both keys accept a comma-separated list to advertise multiple homes.
+When unset, the defaults ``calendars`` and ``contacts`` apply.
+
 Directory Structure
 -------------------
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -142,6 +142,52 @@ class MetadataTests:
         self.assertRaises(KeyError, self._config.get_timezone)
 
 
+class FileBasedPrincipalConfigTests(TestCase):
+    """Tests for the [principal] section in FileBasedCollectionMetadata."""
+
+    def setUp(self):
+        super().setUp()
+        self._config = FileBasedCollectionMetadata()
+
+    def test_calendar_home_set_missing(self):
+        self.assertRaises(KeyError, self._config.get_calendar_home_set)
+
+    def test_calendar_home_set_roundtrip(self):
+        self._config.set_calendar_home_set(["my-cals"])
+        self.assertEqual(["my-cals"], self._config.get_calendar_home_set())
+
+    def test_calendar_home_set_multiple(self):
+        self._config.set_calendar_home_set(["work", "home"])
+        self.assertEqual(["work", "home"], self._config.get_calendar_home_set())
+
+    def test_calendar_home_set_unset(self):
+        self._config.set_calendar_home_set(["my-cals"])
+        self._config.set_calendar_home_set([])
+        self.assertRaises(KeyError, self._config.get_calendar_home_set)
+
+    def test_addressbook_home_set_missing(self):
+        self.assertRaises(KeyError, self._config.get_addressbook_home_set)
+
+    def test_addressbook_home_set_roundtrip(self):
+        self._config.set_addressbook_home_set(["my-contacts"])
+        self.assertEqual(["my-contacts"], self._config.get_addressbook_home_set())
+
+    def test_addressbook_home_set_multiple(self):
+        self._config.set_addressbook_home_set(["personal", "work"])
+        self.assertEqual(["personal", "work"], self._config.get_addressbook_home_set())
+
+    def test_addressbook_home_set_unset(self):
+        self._config.set_addressbook_home_set(["my-contacts"])
+        self._config.set_addressbook_home_set([])
+        self.assertRaises(KeyError, self._config.get_addressbook_home_set)
+
+    def test_unset_removes_empty_section(self):
+        """Unsetting the last principal key drops the section."""
+        self._config.set_calendar_home_set(["my-cals"])
+        self._config.set_calendar_home_set([])
+        self.assertFalse(self._config._configparser.has_section("principal"))
+
+
 class FileMetadataTests(TestCase, MetadataTests):
     def setUp(self):
         super().setUp()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3025,3 +3025,81 @@ class OutboundIMIPTests(unittest.TestCase):
             for m in self.transport.sent
         ]
         self.assertEqual([("dave@elsewhere.example", "REQUEST")], recipients)
+
+
+class PrincipalHomeSetTests(unittest.TestCase):
+    """Per-principal calendar/addressbook-home-set overrides via .xandikos."""
+
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir)
+        self.backend = SingleUserFilesystemBackend(self.tempdir)
+        self.backend.create_principal("/user", create_defaults=False)
+        self.principal = self.backend.get_resource("/user")
+
+    def test_defaults_when_no_config(self):
+        self.assertEqual(["calendars"], self.principal.get_calendar_home_set())
+        self.assertEqual(["contacts"], self.principal.get_addressbook_home_set())
+
+    def test_calendar_home_set_override(self):
+        self.principal.set_calendar_home_set(["my-cals"])
+        self.assertEqual(["my-cals"], self.principal.get_calendar_home_set())
+        # addressbook is unaffected.
+        self.assertEqual(["contacts"], self.principal.get_addressbook_home_set())
+
+    def test_addressbook_home_set_override(self):
+        self.principal.set_addressbook_home_set(["my-contacts"])
+        self.assertEqual(["my-contacts"], self.principal.get_addressbook_home_set())
+        self.assertEqual(["calendars"], self.principal.get_calendar_home_set())
+
+    def test_multiple_homes(self):
+        self.principal.set_calendar_home_set(["work-cal", "home-cal"])
+        self.principal.set_addressbook_home_set(["work-ab", "home-ab"])
+        self.assertEqual(
+            ["work-cal", "home-cal"], self.principal.get_calendar_home_set()
+        )
+        self.assertEqual(
+            ["work-ab", "home-ab"], self.principal.get_addressbook_home_set()
+        )
+
+    def test_override_persists_across_lookups(self):
+        """Override survives backend re-reading the .xandikos file."""
+        self.principal.set_calendar_home_set(["persistent"])
+        # Re-resolve the principal via the backend to bypass any
+        # in-memory caching.
+        fresh = self.backend.get_resource("/user")
+        self.assertEqual(["persistent"], fresh.get_calendar_home_set())
+
+    def test_unset_restores_default(self):
+        self.principal.set_calendar_home_set(["my-cals"])
+        self.principal.set_calendar_home_set([])
+        self.assertEqual(["calendars"], self.principal.get_calendar_home_set())
+
+    def test_create_principal_honours_pre_seeded_override(self):
+        """A pre-seeded .xandikos override drives the principal layout.
+
+        The realistic configure-from-file path: an operator writes a
+        ``.xandikos`` config under the principal directory before the
+        server creates the principal. ``create_principal`` then
+        creates home dirs at the configured paths instead of the
+        defaults.
+        """
+        import configparser
+
+        principal_dir = os.path.join(self.tempdir, "alice")
+        os.makedirs(principal_dir)
+        cp = configparser.ConfigParser()
+        cp.add_section("principal")
+        cp.set("principal", "calendar-home-set", "my-cals")
+        cp.set("principal", "addressbook-home-set", "my-contacts")
+        with open(os.path.join(principal_dir, ".xandikos"), "w") as f:
+            cp.write(f)
+
+        backend = SingleUserFilesystemBackend(self.tempdir)
+        backend.create_principal("/alice", create_defaults=True)
+        self.assertIsNotNone(backend.get_resource("/alice/my-cals/calendar"))
+        self.assertIsNotNone(backend.get_resource("/alice/my-contacts/addressbook"))
+        # Old default paths are not created.
+        self.assertIsNone(backend.get_resource("/alice/calendars"))
+        self.assertIsNone(backend.get_resource("/alice/contacts"))

--- a/xandikos/store/config.py
+++ b/xandikos/store/config.py
@@ -163,6 +163,38 @@ class CollectionMetadata:
         """
         raise NotImplementedError(self.set_schedule_default_calendar_url)
 
+    def get_calendar_home_set(self) -> list[str]:
+        """Get the principal-relative calendar-home-set paths.
+
+        Returns: list of relative paths under the principal.
+        Raises: KeyError if not set
+        """
+        raise NotImplementedError(self.get_calendar_home_set)
+
+    def set_calendar_home_set(self, paths: list[str]) -> None:
+        """Set the principal-relative calendar-home-set paths.
+
+        Args:
+            paths: list of relative paths, or empty list to unset
+        """
+        raise NotImplementedError(self.set_calendar_home_set)
+
+    def get_addressbook_home_set(self) -> list[str]:
+        """Get the principal-relative addressbook-home-set paths.
+
+        Returns: list of relative paths under the principal.
+        Raises: KeyError if not set
+        """
+        raise NotImplementedError(self.get_addressbook_home_set)
+
+    def set_addressbook_home_set(self, paths: list[str]) -> None:
+        """Set the principal-relative addressbook-home-set paths.
+
+        Args:
+            paths: list of relative paths, or empty list to unset
+        """
+        raise NotImplementedError(self.set_addressbook_home_set)
+
 
 class FileBasedCollectionMetadata(CollectionMetadata):
     """Metadata for a configuration."""
@@ -317,4 +349,42 @@ class FileBasedCollectionMetadata(CollectionMetadata):
     def set_schedule_default_calendar_url(self, url):
         self._set_scheduling_option(
             "default-calendar-url", url, "Set schedule-default-calendar-URL."
+        )
+
+    def _set_principal_option(self, key: str, value: str | None, message: str) -> None:
+        if value is not None:
+            if not self._configparser.has_section("principal"):
+                self._configparser.add_section("principal")
+            self._configparser.set("principal", key, value)
+        else:
+            if self._configparser.has_option("principal", key):
+                self._configparser.remove_option("principal", key)
+            if self._configparser.has_section(
+                "principal"
+            ) and not self._configparser.options("principal"):
+                self._configparser.remove_section("principal")
+        self._save(message)
+
+    def _get_principal_path_list(self, key: str) -> list[str]:
+        if not self._configparser.has_option("principal", key):
+            raise KeyError
+        raw = self._configparser.get("principal", key)
+        return [p.strip() for p in raw.split(",") if p.strip()]
+
+    def get_calendar_home_set(self):
+        return self._get_principal_path_list("calendar-home-set")
+
+    def set_calendar_home_set(self, paths):
+        joined = ", ".join(paths) if paths else None
+        self._set_principal_option(
+            "calendar-home-set", joined, "Set calendar-home-set."
+        )
+
+    def get_addressbook_home_set(self):
+        return self._get_principal_path_list("addressbook-home-set")
+
+    def set_addressbook_home_set(self, paths):
+        joined = ", ".join(paths) if paths else None
+        self._set_principal_option(
+            "addressbook-home-set", joined, "Set addressbook-home-set."
         )

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -125,7 +125,6 @@ WELLKNOWN_DAV_PATHS = {
     carddav.WELLKNOWN_CARDDAV_PATH,
 }
 
-# TODO(jelmer): Make these configurable/dynamic
 CALENDAR_HOME_SET = ["calendars"]
 ADDRESSBOOK_HOME_SET = ["contacts"]
 GIT_PATH = ".git"
@@ -1920,10 +1919,44 @@ class Principal(webdav.Principal):
         raise KeyError
 
     def get_calendar_home_set(self):
-        return CALENDAR_HOME_SET
+        """Return calendar-home-set paths for this principal.
+
+        Reads from the principal's ``.xandikos`` config, falling back
+        to :data:`CALENDAR_HOME_SET` when no override is configured.
+        Set via the ``[principal]`` ``calendar-home-set`` key.
+        """
+        try:
+            return self._metadata().get_calendar_home_set()
+        except KeyError:
+            return CALENDAR_HOME_SET
+
+    def set_calendar_home_set(self, paths: list[str]) -> None:
+        """Persist the principal's calendar-home-set override.
+
+        Pass an empty list to unset the override and restore the
+        :data:`CALENDAR_HOME_SET` default.
+        """
+        self._metadata().set_calendar_home_set(paths)
 
     def get_addressbook_home_set(self):
-        return ADDRESSBOOK_HOME_SET
+        """Return addressbook-home-set paths for this principal.
+
+        Reads from the principal's ``.xandikos`` config, falling back
+        to :data:`ADDRESSBOOK_HOME_SET` when no override is configured.
+        Set via the ``[principal]`` ``addressbook-home-set`` key.
+        """
+        try:
+            return self._metadata().get_addressbook_home_set()
+        except KeyError:
+            return ADDRESSBOOK_HOME_SET
+
+    def set_addressbook_home_set(self, paths: list[str]) -> None:
+        """Persist the principal's addressbook-home-set override.
+
+        Pass an empty list to unset the override and restore the
+        :data:`ADDRESSBOOK_HOME_SET` default.
+        """
+        self._metadata().set_addressbook_home_set(paths)
 
     def get_calendar_user_address_set(self):
         """Return this principal's calendar user addresses.


### PR DESCRIPTION
Read calendar-home-set and addressbook-home-set from the principal's ``.xandikos`` config under a new ``[principal]`` section, falling back to the existing ``calendars`` / ``contacts`` defaults.

Fixes #17