### PR TITLE
Don't path-quote scheme URIs in calendar-user-address-set

### DIFF
--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -180,8 +180,8 @@ class CalendarUserAddressSetPropertyTests(unittest.TestCase):
 
             hrefs = el.findall("{DAV:}href")
             self.assertEqual(len(hrefs), 1)
-            # mailto URIs are URL-encoded by create_href
-            self.assertEqual(hrefs[0].text, "mailto%3Auser1%40example.com")
+            # mailto URIs are emitted verbatim, not path-quoted
+            self.assertEqual(hrefs[0].text, "mailto:user1@example.com")
 
         asyncio.run(run_test())
 
@@ -210,9 +210,9 @@ class CalendarUserAddressSetPropertyTests(unittest.TestCase):
 
             hrefs = el.findall("{DAV:}href")
             self.assertEqual(len(hrefs), 3)
-            # Check exact values in order - mailto URIs are URL-encoded by create_href
-            self.assertEqual(hrefs[0].text, "mailto%3Auser1%40example.com")
-            self.assertEqual(hrefs[1].text, "mailto%3Auser1%40otherdomain.com")
+            # mailto URIs are emitted verbatim; path addresses are path-quoted
+            self.assertEqual(hrefs[0].text, "mailto:user1@example.com")
+            self.assertEqual(hrefs[1].text, "mailto:user1@otherdomain.com")
             self.assertEqual(hrefs[2].text, "/principals/user1/")
 
         asyncio.run(run_test())

--- a/xandikos/scheduling.py
+++ b/xandikos/scheduling.py
@@ -24,6 +24,7 @@ See https://tools.ietf.org/html/rfc6638
 
 import datetime
 import posixpath
+import urllib.parse
 from collections.abc import Iterable
 from xml.etree import ElementTree as ET
 
@@ -361,8 +362,14 @@ class CalendarUserAddressSetProperty(webdav.Property):
     in_allprops = False
 
     async def get_value(self, base_href, resource, el, environ):
-        for href in resource.get_calendar_user_address_set():
-            el.append(webdav.create_href(href, base_href))
+        for address in resource.get_calendar_user_address_set():
+            if urllib.parse.urlparse(address).scheme:
+                # URI addresses (e.g. mailto:) are already in canonical form
+                # and must not be path-quoted.
+                href_el = ET.SubElement(el, "{DAV:}href")
+                href_el.text = address
+            else:
+                el.append(webdav.create_href(address, base_href))
 
     async def set_value(self, href, resource, el):
         if el is None:


### PR DESCRIPTION
mailto: addresses were being percent-encoded (mailto%3A...%40...) by create_href, which path-quotes everything but the slash. URIs with a scheme are already canonical; emit them verbatim and only path-quote schemeless path addresses.