### PR TITLE
Accept non-zero Depth for addressbook-multiget

### DIFF
--- a/tests/test_carddav.py
+++ b/tests/test_carddav.py
@@ -22,7 +22,6 @@ import unittest
 
 from xandikos.carddav import NAMESPACE, AddressDataProperty
 from xandikos.vcard import VCardFile, CardDAVFilter, parse_filter
-from xandikos import webdav
 from xandikos.webdav import ET
 from .test_vcard import EXAMPLE_VCARD1
 
@@ -135,11 +134,13 @@ class AddressbookMultigetReporterTests(unittest.TestCase):
         reporter = AddressbookMultiGetReporter()
         self.assertEqual(reporter.resource_type, ADDRESSBOOK_RESOURCE_TYPE)
 
-    def test_depth_validation_strict_mode(self):
-        """Test that Depth: 0 is enforced in strict mode.
+    def test_depth_header_ignored(self):
+        """Test that the Depth header is ignored, even in strict mode.
 
-        RFC 6352 Section 8.7 requires Depth: 0 for addressbook-multiget.
-        In strict mode, non-zero depth values should be rejected.
+        RFC 6352 Section 8.7 says addressbook-multiget "MUST include a
+        Depth: 0 header", but the examples in that section use Depth: 1 and
+        errata EID 4610 recommends Depth: 1. Depth is meaningless for a
+        multiget, so non-zero values are accepted.
         """
         from xandikos.carddav import AddressbookMultiGetReporter
 
@@ -147,33 +148,17 @@ class AddressbookMultigetReporterTests(unittest.TestCase):
             reporter = AddressbookMultiGetReporter()
             body = ET.Element("body")
 
-            # Test with depth "1" in strict mode - should raise error
-            with self.assertRaises(webdav.BadRequestError) as cm:
-                await reporter.report(
+            for depth in ("0", "1", "infinity"):
+                response = await reporter.report(
                     environ={},
                     body=body,
                     resources_by_hrefs=lambda hrefs: [],
                     properties={},
                     base_href="/",
                     resource=None,
-                    depth="1",
+                    depth=depth,
                     strict=True,
                 )
-            self.assertIn("Depth: 0", str(cm.exception))
-            self.assertIn("RFC 6352", str(cm.exception))
-
-            # Test with depth "infinity" in strict mode - should raise error
-            with self.assertRaises(webdav.BadRequestError) as cm:
-                await reporter.report(
-                    environ={},
-                    body=body,
-                    resources_by_hrefs=lambda hrefs: [],
-                    properties={},
-                    base_href="/",
-                    resource=None,
-                    depth="infinity",
-                    strict=True,
-                )
-            self.assertIn("Depth: 0", str(cm.exception))
+                self.assertEqual(response.status, 207)
 
         asyncio.run(run_test())

--- a/xandikos/carddav.py
+++ b/xandikos/carddav.py
@@ -96,46 +96,18 @@ class AddressbookDescriptionProperty(webdav.Property):
 
 
 class AddressbookMultiGetReporter(davcommon.MultiGetReporter):
+    # RFC 6352 Section 8.7 (CardDAV addressbook-multiget) says the request
+    # "MUST include a Depth: 0 header", but both examples in that same section
+    # show Depth: 1, and errata EID 4610 (https://www.rfc-editor.org/errata/eid4610)
+    # recommends Depth: 1 instead. Depth is meaningless for a multiget anyway,
+    # since the request body enumerates the exact hrefs to return.
+    #
+    # We therefore ignore the Depth header here, matching how
+    # CalendarMultiGetReporter handles calendar-multiget, and accept clients
+    # such as pimsync that send Depth: 1.
     name = "{%s}addressbook-multiget" % NAMESPACE
     resource_type = ADDRESSBOOK_RESOURCE_TYPE
     data_property = AddressDataProperty()
-
-    async def report(
-        self,
-        environ,
-        body,
-        resources_by_hrefs,
-        properties,
-        base_href,
-        resource,
-        depth,
-        strict,
-    ):
-        # RFC 6352 Section 8.7 (CardDAV addressbook-multiget) specifies:
-        #   "The request MUST include a Depth: 0 header on the request."
-        #
-        # This is a client requirement, and the RFC doesn't explicitly mandate
-        # that servers MUST reject requests with other Depth values. However,
-        # in strict mode, we enforce this requirement to ensure full RFC
-        # compliance and catch misbehaving clients.
-        #
-        # In non-strict mode, we accept any Depth value for compatibility with
-        # existing clients that may send non-zero Depth headers.
-        if strict and depth != "0":
-            raise webdav.BadRequestError(
-                f"{self.name} requires Depth: 0 (RFC 6352 Section 8.7), "
-                f"got Depth: {depth}"
-            )
-        return await super().report(
-            environ,
-            body,
-            resources_by_hrefs,
-            properties,
-            base_href,
-            resource,
-            depth,
-            strict,
-        )
 
 
 class Addressbook(webdav.Collection):


### PR DESCRIPTION
RFC 6352 8.7 says addressbook-multiget MUST use Depth: 0, but its own examples use Depth: 1 and errata EID 4610 recommends Depth: 1. Depth is meaningless for a multiget, so ignore it as calendar-multiget already does, rather than rejecting clients such as pimsync in strict mode.

Fixes #692