### PR TITLE
Fix crash when DTSTART is a date but RRULE UNTIL is a tz-aware datetime

### DIFF
--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -1866,8 +1866,15 @@ def _normalize_rrule_until(rrule_str: str, dtstart: date | datetime) -> str:
     Returns:
         The RRULE string, possibly modified to have UNTIL in UTC format
     """
-    # Only normalize if dtstart is a timezone-aware datetime
+    # If dtstart is a plain date or naive datetime, UNTIL must also be naive
+    # because dateutil converts date/naive-datetime dtstart to naive internally
     if not isinstance(dtstart, datetime) or dtstart.tzinfo is None:
+        parsed = vRecur.from_ical(rrule_str)
+        if "UNTIL" in parsed:
+            until_list = parsed["UNTIL"]
+            if until_list and isinstance(until_list[0], datetime) and until_list[0].tzinfo is not None:
+                parsed["UNTIL"] = [until_list[0].replace(tzinfo=None)]
+                return parsed.to_ical().decode("utf-8")
         return rrule_str
 
     parsed = vRecur.from_ical(rrule_str)


### PR DESCRIPTION
When `DTSTART` is a plain date and the `RRULE` has an `UNTIL` with a UTC suffix (e.g. `UNTIL=20220625T000000Z`), dateutil raises a ValueError because it internally converts the date to a naive datetime, then chokes on the timezone-aware `UNTIL` value.

This happens with birthday/anniversary calendars exported from Google Calendar. Real-world example that triggers the crash:

```ics
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//Google Inc//Google Calendar 70.9054//EN
CALSCALE:GREGORIAN
X-WR-CALNAME:Geburtsdaten
X-WR-TIMEZONE:Europe/Berlin
BEGIN:VEVENT
SUMMARY:<redacted>
DTSTART;VALUE=DATE:20170626
DTEND;VALUE=DATE:20170627
DTSTAMP:20220628T050908Z
UID:<redacred>@google.com
SEQUENCE:1
RRULE:FREQ=YEARLY;UNTIL=20220625T000000Z;WKST=MO
CREATED:20170626T194206Z
DESCRIPTION:
LAST-MODIFIED:20220628T050908Z
LOCATION:
STATUS:CONFIRMED
TRANSP:TRANSPARENT
END:VEVENT
END:VCALENDAR
```

The existing `_normalize_rrule_until` function already handles the inverse case (tz-aware `DTSTART` + naive `UNTIL`) but the plain-date/naive-datetime path just returned the rrule string unchanged.

Fix: when dtstart is a date or naive datetime, check whether `UNTIL` is timezone-aware and strip the tzinfo if so. This makes both sides naive, which is what dateutil expects.

Traceback without fix:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/aiohttp/web_protocol.py", line 575, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/web_app.py", line 559, in _handle
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp_openmetrics/__init__.py", line 79, in metrics_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/web.py", line 3006, in xandikos_handler
    return await main_app.aiohttp_handler(request, options.route_prefix)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/webdav.py", line 3459, in aiohttp_handler
    response = await self._handle_request(request, environ)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/web.py", line 2503, in _handle_request
    return await super()._handle_request(request, environ)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/webdav.py", line 3410, in _handle_request
    return await do.handle(request, environ, self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/webdav.py", line 2855, in handle
    return await reporter.report(
           ^^^^^^^^^^^^^^^^^^^^^^
    ...<13 lines>...
    )
    ^
  File "/code/xandikos/webdav.py", line 454, in wrapper
    async for resp in req_fn(self, environ, *args, **kwargs):
        responses.append(resp)
  File "/code/xandikos/caldav.py", line 632, in report
    async for href, resource in webdav.traverse_resource(
    ...<14 lines>...
            )
  File "/code/xandikos/webdav.py", line 1694, in traverse_resource
    for child_name, child_resource in members_fn(resource):
                                      ~~~~~~~~~~^^^^^^^^^^
  File "/code/xandikos/web.py", line 1162, in calendar_query
    for name, file, etag in self.store.iter_with_filter(filter=filter):
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/code/xandikos/store/__init__.py", line 439, in _iter_with_filter_indexes
    if filter.check(name, file):
       ~~~~~~~~~~~~^^^^^^^^^^^^
  File "/code/xandikos/icalendar.py", line 1536, in check
    c = file.get_expanded_calendar(time_range.start, time_range.end)
  File "/code/xandikos/icalendar.py", line 1673, in get_expanded_calendar
    return expand_calendar_rrule(self.calendar, start, end)
  File "/code/xandikos/icalendar.py", line 2258, in expand_calendar_rrule
    for expanded in _expand_rrule_component(comp, start, end, exceptions):
                    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/icalendar.py", line 2122, in _expand_rrule_component
    rs = rruleset_from_comp(incomp)
  File "/code/xandikos/icalendar.py", line 1910, in rruleset_from_comp
    rrule = dateutil.rrule.rrulestr(rrulestr, dtstart=dtstart)
  File "/usr/lib/python3/dist-packages/dateutil/rrule.py", line 1732, in __call__
    return self._parse_rfc(s, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dateutil/rrule.py", line 1652, in _parse_rfc
    return self._parse_rfc_rrule(lines[0], cache=cache,
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
                                 dtstart=dtstart, ignoretz=ignoretz,
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                 tzinfos=tzinfos)
                                 ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dateutil/rrule.py", line 1561, in _parse_rfc_rrule
    return rrule(dtstart=dtstart, cache=cache, **rrkwargs)
  File "/usr/lib/python3/dist-packages/dateutil/rrule.py", line 470, in __init__
    raise ValueError(
    ...<2 lines>...
    )
ValueError: RRULE UNTIL values must be specified in UTC when DTSTART is timezone-aware
```

Affects at least Google-exported birthday calendars synced via DAVx5/KOrganizer.