### PR TITLE
Avoid unnecessary recurrence expansion in time-range queries (huge performance improvement)

### DIFF
--- a/benchmarks/bench_rrule.py
+++ b/benchmarks/bench_rrule.py
@@ -1,0 +1,187 @@
+# Xandikos
+# Copyright (C) 2025-2026 Jelmer Vernooĳ <jelmer@jelmer.uk>, et al.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 3
+# of the License or (at your option) any later version of
+# the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301, USA.
+
+"""Indexed calendar-query benchmarks on recurring-event collections.
+
+These exercise the KOrganizer/DAVx5 workload from PR #703. Each fixture
+file has a single yearly-recurring VEVENT (a birthday). The client sends
+open-ended time-range calendar-query REPORTs for VTODO, VJOURNAL, and
+VEVENT.
+
+Before PR #703:
+  - VTODO/VJOURNAL queries triggered InsufficientIndexDataError for every
+    file, forcing a full-file check and RRULE expansion.
+  - VEVENT queries eagerly materialized up to MAX_RECURRENCE_INSTANCES
+    (3000) occurrences per file before testing the first hit.
+
+After PR #703 both paths are indexed and lazy, and these benchmarks drop
+by two to three orders of magnitude.
+
+Run:
+    pytest benchmarks/ --benchmark-enable
+    pytest benchmarks/ --benchmark-enable --benchmark-save=<label>
+    pytest-benchmark compare <label1> <label2> --sort=fullname
+"""
+
+from datetime import datetime, timezone
+
+from xandikos.icalendar import CalendarFilter, MAX_EXPANSION_TIME
+
+from .conftest import BIRTHDAY_LARGE_COLLECTION, BIRTHDAY_SMALL_COLLECTION
+
+
+def _make_open_ended_filter(comp_name):
+    """Build an open-ended time-range filter for a given component type.
+
+    The end is MAX_EXPANSION_TIME, matching the "no end" queries KOrganizer
+    and DAVx5 issue for their VTODO/VJOURNAL/VEVENT calendar-query REPORTs.
+    """
+    f = CalendarFilter(timezone.utc)
+    f.filter_subcomponent("VCALENDAR").filter_subcomponent(comp_name).filter_time_range(
+        datetime(2026, 4, 6, 0, 4, tzinfo=timezone.utc),
+        MAX_EXPANSION_TIME,
+    )
+    return f
+
+
+class TestOpenEndedVTodoQuery:
+    """Open-ended VTODO time-range against a birthday (VEVENT-only) collection.
+
+    Before PR #703 every file fell back to a full-file check because the
+    VTODO time-range matcher could not decide from indexes and raised
+    InsufficientIndexDataError. Each fallback then expanded the yearly
+    RRULE.
+    """
+
+    def _run(self, store):
+        return list(store.iter_with_filter(_make_open_ended_filter("VTODO")))
+
+    def test_bare_small(self, benchmark, bare_birthday_store_small):
+        store, _ = bare_birthday_store_small
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+    def test_bare_large(self, benchmark, bare_birthday_store_large):
+        store, _ = bare_birthday_store_large
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+    def test_tree_small(self, benchmark, tree_birthday_store_small):
+        store, _ = tree_birthday_store_small
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+    def test_tree_large(self, benchmark, tree_birthday_store_large):
+        store, _ = tree_birthday_store_large
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+    def test_memory_small(self, benchmark, memory_birthday_store_small):
+        store, _ = memory_birthday_store_small
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+    def test_memory_large(self, benchmark, memory_birthday_store_large):
+        store, _ = memory_birthday_store_large
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+
+class TestOpenEndedVJournalQuery:
+    """Open-ended VJOURNAL time-range against a birthday collection.
+
+    Symmetric to the VTODO case and covered by the same match_indexes
+    short-circuit.
+    """
+
+    def _run(self, store):
+        return list(store.iter_with_filter(_make_open_ended_filter("VJOURNAL")))
+
+    def test_bare_small(self, benchmark, bare_birthday_store_small):
+        store, _ = bare_birthday_store_small
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+    def test_bare_large(self, benchmark, bare_birthday_store_large):
+        store, _ = bare_birthday_store_large
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+    def test_tree_small(self, benchmark, tree_birthday_store_small):
+        store, _ = tree_birthday_store_small
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+    def test_tree_large(self, benchmark, tree_birthday_store_large):
+        store, _ = tree_birthday_store_large
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+    def test_memory_small(self, benchmark, memory_birthday_store_small):
+        store, _ = memory_birthday_store_small
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+    def test_memory_large(self, benchmark, memory_birthday_store_large):
+        store, _ = memory_birthday_store_large
+        result = benchmark(self._run, store)
+        assert len(result) == 0
+
+
+class TestOpenEndedVEventQuery:
+    """Open-ended VEVENT time-range against a birthday collection.
+
+    Each file matches (the yearly RRULE hits the query window). Before
+    PR #703 _get_occurrences_in_range materialized up to
+    MAX_RECURRENCE_INSTANCES occurrences before testing the first hit;
+    after the fix the underlying iterator is consumed lazily.
+    """
+
+    def _run(self, store):
+        return list(store.iter_with_filter(_make_open_ended_filter("VEVENT")))
+
+    def test_bare_small(self, benchmark, bare_birthday_store_small):
+        store, _ = bare_birthday_store_small
+        result = benchmark(self._run, store)
+        assert len(result) == BIRTHDAY_SMALL_COLLECTION
+
+    def test_bare_large(self, benchmark, bare_birthday_store_large):
+        store, _ = bare_birthday_store_large
+        result = benchmark(self._run, store)
+        assert len(result) == BIRTHDAY_LARGE_COLLECTION
+
+    def test_tree_small(self, benchmark, tree_birthday_store_small):
+        store, _ = tree_birthday_store_small
+        result = benchmark(self._run, store)
+        assert len(result) == BIRTHDAY_SMALL_COLLECTION
+
+    def test_tree_large(self, benchmark, tree_birthday_store_large):
+        store, _ = tree_birthday_store_large
+        result = benchmark(self._run, store)
+        assert len(result) == BIRTHDAY_LARGE_COLLECTION
+
+    def test_memory_small(self, benchmark, memory_birthday_store_small):
+        store, _ = memory_birthday_store_small
+        result = benchmark(self._run, store)
+        assert len(result) == BIRTHDAY_SMALL_COLLECTION
+
+    def test_memory_large(self, benchmark, memory_birthday_store_large):
+        store, _ = memory_birthday_store_large
+        result = benchmark(self._run, store)
+        assert len(result) == BIRTHDAY_LARGE_COLLECTION

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -73,6 +73,12 @@ from xandikos.store.memory import MemoryStore  # noqa: E402
 SMALL_COLLECTION = 50
 LARGE_COLLECTION = 500
 
+# Birthday-style collections use smaller sizes because each item has an
+# unbounded yearly RRULE that historically expanded to MAX_RECURRENCE_INSTANCES
+# per file on the fallback path. See bench_rrule.py.
+BIRTHDAY_SMALL_COLLECTION = 50
+BIRTHDAY_LARGE_COLLECTION = 200
+
 
 def _make_vcalendar(i: int, base_date: datetime) -> bytes:
     """Generate a VCALENDAR with a single VEVENT."""
@@ -87,6 +93,28 @@ def _make_vcalendar(i: int, base_date: datetime) -> bytes:
         + f"DTSTART:{event_date.strftime('%Y%m%dT%H%M%SZ')}\r\n".encode()
         + f"DTEND:{end_date.strftime('%Y%m%dT%H%M%SZ')}\r\n".encode()
         + f"SUMMARY:Benchmark Event {i}\r\n".encode()
+        + b"END:VEVENT\r\n"
+        b"END:VCALENDAR\r\n"
+    )
+
+
+def _make_birthday_vcalendar(i: int) -> bytes:
+    """Generate a VCALENDAR with a yearly-recurring all-day VEVENT.
+
+    Mirrors the birthday calendars produced by DAVx5/KOrganizer that
+    motivated PR #703: each file has one FREQ=YEARLY event with no UNTIL.
+    """
+    month = 1 + (i % 12)
+    day = 1 + (i % 28)
+    return (
+        b"BEGIN:VCALENDAR\r\n"
+        b"VERSION:2.0\r\n"
+        b"PRODID:-//Xandikos Bench//EN\r\n"
+        b"BEGIN:VEVENT\r\n"
+        + f"UID:bench-bday-{i}@example.com\r\n".encode()
+        + f"DTSTART;VALUE=DATE:1980{month:02d}{day:02d}\r\n".encode()
+        + f"SUMMARY:Birthday {i}\r\n".encode()
+        + b"RRULE:FREQ=YEARLY\r\n"
         + b"END:VEVENT\r\n"
         b"END:VCALENDAR\r\n"
     )
@@ -113,6 +141,19 @@ def _populate_store(store, n):
         name = f"event-{i}.ics"
         (name, etag) = _import_one(
             store, name, "text/calendar", [_make_vcalendar(i, base_date)]
+        )
+        etags[name] = etag
+    return etags
+
+
+def _populate_birthday_store(store, n):
+    """Add *n* yearly-recurring events (birthdays) to *store*."""
+    store.load_extra_file_handler(ICalendarFile)
+    etags = {}
+    for i in range(n):
+        name = f"bday-{i}.ics"
+        (name, etag) = _import_one(
+            store, name, "text/calendar", [_make_birthday_vcalendar(i)]
         )
         etags[name] = etag
     return etags
@@ -173,6 +214,48 @@ def memory_store_small():
 def memory_store_large():
     store = MemoryStore()
     etags = _populate_store(store, LARGE_COLLECTION)
+    return store, etags
+
+
+@pytest.fixture(scope="session")
+def bare_birthday_store_small():
+    store = BareGitStore.create_memory()
+    etags = _populate_birthday_store(store, BIRTHDAY_SMALL_COLLECTION)
+    return store, etags
+
+
+@pytest.fixture(scope="session")
+def bare_birthday_store_large():
+    store = BareGitStore.create_memory()
+    etags = _populate_birthday_store(store, BIRTHDAY_LARGE_COLLECTION)
+    return store, etags
+
+
+@pytest.fixture(scope="session")
+def tree_birthday_store_small(_tree_store_dir):
+    store = TreeGitStore.create(os.path.join(_tree_store_dir, "bday-small"))
+    etags = _populate_birthday_store(store, BIRTHDAY_SMALL_COLLECTION)
+    return store, etags
+
+
+@pytest.fixture(scope="session")
+def tree_birthday_store_large(_tree_store_dir):
+    store = TreeGitStore.create(os.path.join(_tree_store_dir, "bday-large"))
+    etags = _populate_birthday_store(store, BIRTHDAY_LARGE_COLLECTION)
+    return store, etags
+
+
+@pytest.fixture(scope="session")
+def memory_birthday_store_small():
+    store = MemoryStore()
+    etags = _populate_birthday_store(store, BIRTHDAY_SMALL_COLLECTION)
+    return store, etags
+
+
+@pytest.fixture(scope="session")
+def memory_birthday_store_large():
+    store = MemoryStore()
+    etags = _populate_birthday_store(store, BIRTHDAY_LARGE_COLLECTION)
     return store, etags
 
 

--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -719,6 +719,60 @@ class CalendarFilterTests(unittest.TestCase):
         )
         self.assertTrue(filter.check("file", self.cal))
 
+    def test_comp_time_range_absent_component_short_circuits(self):
+        # Regression: a comp-filter with a time-range on a component that is
+        # absent from the file (e.g. VTODO in a calendar containing only
+        # VEVENTs) must resolve to False from indexes alone, without falling
+        # back through InsufficientIndexDataError. This is the fast path that
+        # keeps empty VTODO/VJOURNAL queries from expanding recurrences for
+        # every file in the collection.
+        filter = CalendarFilter(ZoneInfo("UTC"))
+        filter.filter_subcomponent("VCALENDAR").filter_subcomponent(
+            "VTODO"
+        ).filter_time_range(
+            self._tzify(datetime(2026, 4, 6, 0, 4, 0)),
+            self._tzify(datetime(2027, 4, 6, 0, 4, 0)),
+        )
+        # Indexes as they would be returned for a file with only VEVENTs:
+        # C=VCALENDAR/C=VTODO is present in the index but empty.
+        indexes = {
+            "C=VCALENDAR/C=VTODO": [],
+            "C=VCALENDAR/C=VTODO/P=DTSTART": [],
+            "C=VCALENDAR/C=VTODO/P=DUE": [],
+            "C=VCALENDAR/C=VTODO/P=DURATION": [],
+            "C=VCALENDAR/C=VTODO/P=CREATED": [],
+            "C=VCALENDAR/C=VTODO/P=COMPLETED": [],
+            "C=VCALENDAR/C=VTODO/P=RRULE": [],
+        }
+        self.assertFalse(filter.check_from_indexes("file", indexes))
+
+    def test_comp_time_range_lazy_rrule_expansion(self):
+        # Regression: _get_occurrences_in_range must not eagerly materialize up
+        # to MAX_RECURRENCE_INSTANCES entries when the query end is unbounded.
+        # It should return an iterator so _test_occurrences can stop on the
+        # first match.
+        from xandikos.icalendar import (
+            ComponentTimeRangeMatcher,
+            MAX_EXPANSION_TIME,
+        )
+        from dateutil.rrule import rrule as _rrule, YEARLY
+
+        matcher = ComponentTimeRangeMatcher(
+            self._tzify(datetime(2026, 1, 1)),
+            MAX_EXPANSION_TIME,
+            comp="VEVENT",
+        )
+        dtstart = self._tzify(datetime(2000, 5, 27, 22, 19, 52))
+        rr = _rrule(YEARLY, dtstart=dtstart)
+        occurrences = matcher._get_occurrences_in_range(
+            rr, dtstart, matcher.start, matcher.end
+        )
+        # The result must be lazy: not a materialized list/tuple.
+        self.assertNotIsInstance(occurrences, (list, tuple))
+        # And it must still yield the expected occurrences within the range.
+        first = next(iter(occurrences))
+        self.assertEqual(first, self._tzify(datetime(2026, 5, 27, 22, 19, 52)))
+
     def test_filter_rrule_without_dtstart(self):
         # A stored VTODO with RRULE but no DTSTART (RFC 5545 3.8.5.3 makes it
         # malformed) must not crash either filter path. Both warn and skip.

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -1030,12 +1030,14 @@ class ComponentTimeRangeMatcher:
         )
         max_date = MAX_EXPANSION_TIME.date()
         if query_end_date >= max_date:
-            # Use xafter with count limit for unbounded queries
-            occurrences = list(
-                rrule.xafter(start_normalized, count=MAX_RECURRENCE_INSTANCES, inc=True)
+            # Use a lazy xafter iterator so matching can stop at the first hit.
+            return (
+                occ
+                for occ in rrule.xafter(
+                    start_normalized, count=MAX_RECURRENCE_INSTANCES, inc=True
+                )
+                if occ <= end_normalized
             )
-            # Filter to only those before end_normalized
-            return [occ for occ in occurrences if occ <= end_normalized]
         else:
             return list(rrule.between(start_normalized, end_normalized, inc=True))
 
@@ -1293,6 +1295,9 @@ class ComponentFilter:
         myindex = "C=" + self.name
         if self.is_not_defined:
             return not bool(indexes[myindex])
+
+        if myindex in indexes and not indexes[myindex]:
+            return False
 
         subindexes = create_subindexes(indexes, myindex)
 


### PR DESCRIPTION
This fixes a slow path I hit with KOrganizer against a birthday calendar.

KOrganizer sends three separate `calendar-query` REPORTs for the same calendar:
`VTODO`, `VJOURNAL`, and `VEVENT`, each with a time range starting at `20260406T000400Z`. The calendar itself only contains events, mostly yearly all-day recurring birthdays.

The results were correct if the client waited long enough, but the server spent a lot of time doing work that could be skipped. In the packet capture KOrganizer closed the slow requests after about 60 seconds. And this made the whole birthday calendar entries never appear in KOrganizer (and DAVx5).

There are two changes here:

First, `ComponentFilter.match_indexes()` now returns `False` when the requested component index is present and empty:

```python
if myindex in indexes and not indexes[myindex]:
    return False
```

For example, if the query asks for `VTODO` and the file only contains `VEVENT`, the index has already answered the question:

```python
indexes["C=VCALENDAR/C=VTODO"] == []
```

The previous code still descended into the time-range matcher. That raised `InsufficientIndexDataError`, which made the store fall back to a full file check. The full check expands recurrences before the component mismatch is
rejected, so empty `VTODO` and `VJOURNAL` queries were expanding yearly birthday events just to return no matches.

This does not change `is-not-defined` handling; that case returns before the new check.

Second, open-ended recurrence matching now stays lazy. The old code did this:

```python
occurrences = list(rrule.xafter(...))
return [occ for occ in occurrences if occ <= end_normalized]
```

That builds up to `MAX_RECURRENCE_INSTANCES` occurrences before the caller can test any of them. For a time-range filter we usually only need to know whether one occurrence matches.

The new code returns a generator instead:

```python
return (
    occ for occ in rrule.xafter(...)
    if occ <= end_normalized
)
```

The same cap still applies, but the match loop can stop on the first hit.

Measured on the same calendar, 78 `.ics` files:

| query | before | after | response |
| --- | ---: | ---: | --- |
| `VTODO` | 36.4 s | 0.050 s | empty |
| `VJOURNAL` | 35.5 s | 0.015 s | empty |
| `VEVENT` | 11.6 s | 0.070 s | 34 hrefs |

Before the patch, the empty component queries fell back for every file:

| query | files | fallbacks | fallback time |
| --- | ---: | ---: | ---: |
| `VTODO` | 78 | 78 | 36.2 s |
| `VJOURNAL` | 78 | 78 | 35.3 s |
| `VEVENT` | 78 | 0 | 0.0 s |

The `VEVENT` query was already using indexes, but still paid for eager recurrence materialization. Making that iterator lazy brings it down to the same range as the other indexed checks.
