### PR TITLE
rrule normalization: Handle inconsistent UNTIL/RRULE entries

### DIFF
--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -3131,7 +3131,7 @@ class NormalizeRruleUntilTests(unittest.TestCase):
         normalized = _normalize_rrule_until(rrule_str, dtstart)
 
         # UNTIL should have Z stripped (naive datetime)
-        self.assertEqual("FREQ=YEARLY;UNTIL=20220625T000000Z;WKST=MO", normalized)
+        self.assertEqual("FREQ=YEARLY;UNTIL=20220625T000000;WKST=MO", normalized)
 
     def test_naive_dtstart_with_utc_until_strips_tzinfo(self):
         """Test that UTC UNTIL is stripped when DTSTART is a naive datetime."""

--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -3110,6 +3110,41 @@ class NormalizeRruleUntilTests(unittest.TestCase):
         # Should be unchanged
         self.assertEqual(normalized, rrule_str)
 
+    def test_date_dtstart_with_utc_until_strips_tzinfo(self):
+        """Test that UTC UNTIL is stripped when DTSTART is date-only.
+
+        Older Google Calendar exports (circa 2015) produced non-conformant
+        RRULE output for whole-day recurring events: DTSTART as a plain
+        date but UNTIL with a UTC suffix (e.g. UNTIL=20220625T000000Z).
+        This happened when future occurrences of a recurring event were
+        deleted — Google added a UTC UNTIL to bound the recurrence.
+        Current Google Calendar output is conformant (plain-date UNTIL for
+        whole-day events), but older entries may still exist in calendars.
+
+        dateutil converts the plain-date DTSTART to a naive datetime
+        internally, then raises ValueError because UNTIL is timezone-aware.
+        The fix strips the tzinfo from UNTIL to make both sides naive.
+        """
+        rrule_str = "FREQ=YEARLY;UNTIL=20220625T000000Z;WKST=MO"
+        dtstart = date(2017, 6, 26)  # Plain date, as in Google birthday calendar
+
+        normalized = _normalize_rrule_until(rrule_str, dtstart)
+
+        # UNTIL should have Z stripped (naive datetime)
+        self.assertIn("UNTIL=20220625T000000", normalized)
+        self.assertNotIn("UNTIL=20220625T000000Z", normalized)
+
+    def test_naive_dtstart_with_utc_until_strips_tzinfo(self):
+        """Test that UTC UNTIL is stripped when DTSTART is a naive datetime."""
+        rrule_str = "FREQ=YEARLY;UNTIL=20220625T000000Z;WKST=MO"
+        dtstart = datetime(2017, 6, 26, 0, 0, 0)  # Naive datetime
+
+        normalized = _normalize_rrule_until(rrule_str, dtstart)
+
+        # UNTIL should have Z stripped (naive datetime)
+        self.assertIn("UNTIL=20220625T000000", normalized)
+        self.assertNotIn("UNTIL=20220625T000000Z", normalized)
+
     def test_expand_rrule_with_naive_until(self):
         """Test that expand_calendar_rrule works with naive UNTIL (issue #571)."""
         # This is the specific case from iPhone clients

--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -3131,8 +3131,7 @@ class NormalizeRruleUntilTests(unittest.TestCase):
         normalized = _normalize_rrule_until(rrule_str, dtstart)
 
         # UNTIL should have Z stripped (naive datetime)
-        self.assertIn("UNTIL=20220625T000000", normalized)
-        self.assertNotIn("UNTIL=20220625T000000Z", normalized)
+        self.assertEqual("FREQ=YEARLY;UNTIL=20220625T000000Z;WKST=MO", normalized)
 
     def test_naive_dtstart_with_utc_until_strips_tzinfo(self):
         """Test that UTC UNTIL is stripped when DTSTART is a naive datetime."""
@@ -3142,8 +3141,7 @@ class NormalizeRruleUntilTests(unittest.TestCase):
         normalized = _normalize_rrule_until(rrule_str, dtstart)
 
         # UNTIL should have Z stripped (naive datetime)
-        self.assertIn("UNTIL=20220625T000000", normalized)
-        self.assertNotIn("UNTIL=20220625T000000Z", normalized)
+        self.assertEqual("FREQ=YEARLY;UNTIL=20220625T000000;WKST=MO", normalized)
 
     def test_expand_rrule_with_naive_until(self):
         """Test that expand_calendar_rrule works with naive UNTIL (issue #571)."""

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -1871,8 +1871,15 @@ def _normalize_rrule_until(rrule_str: str, dtstart: date | datetime) -> str:
     Returns:
         The RRULE string, possibly modified to have UNTIL in UTC format
     """
-    # Only normalize if dtstart is a timezone-aware datetime
+    # If dtstart is a plain date or naive datetime, UNTIL must also be naive
+    # because dateutil converts date/naive-datetime dtstart to naive internally
     if not isinstance(dtstart, datetime) or dtstart.tzinfo is None:
+        parsed = vRecur.from_ical(rrule_str)
+        if "UNTIL" in parsed:
+            until_list = parsed["UNTIL"]
+            if until_list and isinstance(until_list[0], datetime) and until_list[0].tzinfo is not None:
+                parsed["UNTIL"] = [until_list[0].replace(tzinfo=None)]
+                return parsed.to_ical().decode("utf-8")
         return rrule_str
 
     parsed = vRecur.from_ical(rrule_str)

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -1877,7 +1877,11 @@ def _normalize_rrule_until(rrule_str: str, dtstart: date | datetime) -> str:
         parsed = vRecur.from_ical(rrule_str)
         if "UNTIL" in parsed:
             until_list = parsed["UNTIL"]
-            if until_list and isinstance(until_list[0], datetime) and until_list[0].tzinfo is not None:
+            if (
+                until_list
+                and isinstance(until_list[0], datetime)
+                and until_list[0].tzinfo is not None
+            ):
                 parsed["UNTIL"] = [until_list[0].replace(tzinfo=None)]
                 return parsed.to_ical().decode("utf-8")
         return rrule_str

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -1871,21 +1871,6 @@ def _normalize_rrule_until(rrule_str: str, dtstart: date | datetime) -> str:
     Returns:
         The RRULE string, possibly modified to have UNTIL in UTC format
     """
-    # If dtstart is a plain date or naive datetime, UNTIL must also be naive
-    # because dateutil converts date/naive-datetime dtstart to naive internally
-    if not isinstance(dtstart, datetime) or dtstart.tzinfo is None:
-        parsed = vRecur.from_ical(rrule_str)
-        if "UNTIL" in parsed:
-            until_list = parsed["UNTIL"]
-            if (
-                until_list
-                and isinstance(until_list[0], datetime)
-                and until_list[0].tzinfo is not None
-            ):
-                parsed["UNTIL"] = [until_list[0].replace(tzinfo=None)]
-                return parsed.to_ical().decode("utf-8")
-        return rrule_str
-
     parsed = vRecur.from_ical(rrule_str)
 
     if "UNTIL" not in parsed:
@@ -1897,6 +1882,14 @@ def _normalize_rrule_until(rrule_str: str, dtstart: date | datetime) -> str:
         return rrule_str
 
     until = until_list[0]
+
+    # If dtstart is a plain date or naive datetime, UNTIL must also be naive
+    # because dateutil converts date/naive-datetime dtstart to naive internally
+    if not isinstance(dtstart, datetime) or dtstart.tzinfo is None:
+        if isinstance(until, datetime) and until.tzinfo is not None:
+            parsed["UNTIL"] = [until.replace(tzinfo=None)]
+            return parsed.to_ical().decode("utf-8")
+        return rrule_str
 
     # If UNTIL is a date (not datetime), convert to end of day in UTC
     if isinstance(until, date) and not isinstance(until, datetime):

--- a/xandikos/store/git.py
+++ b/xandikos/store/git.py
@@ -40,7 +40,7 @@ from dulwich.index import (
     locked_index,
 )
 from dulwich.objects import Blob, Commit, Tree
-from dulwich.porcelain import get_user_identity
+from dulwich.repo import get_user_identity
 
 from . import (
     DEFAULT_MIME_TYPE,


### PR DESCRIPTION
Follow up of #702

When `DTSTART` is a plain date and the `RRULE` has an `UNTIL` with a UTC suffix (e.g. `UNTIL=20220625T000000Z`), dateutil raises a ValueError because it internally converts the date to a naive datetime, then chokes on the timezone-aware `UNTIL` value.

This happens with birthday/anniversary calendars exported from Google Calendar. Real-world example that triggers the crash:

```ics
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//Google Inc//Google Calendar 70.9054//EN
CALSCALE:GREGORIAN
X-WR-CALNAME:Geburtsdaten
X-WR-TIMEZONE:Europe/Berlin
BEGIN:VEVENT
SUMMARY:<redacted>
DTSTART;VALUE=DATE:20170626
DTEND;VALUE=DATE:20170627
DTSTAMP:20220628T050908Z
UID:<redacred>@google.com
SEQUENCE:1
RRULE:FREQ=YEARLY;UNTIL=20220625T000000Z;WKST=MO
CREATED:20170626T194206Z
DESCRIPTION:
LAST-MODIFIED:20220628T050908Z
LOCATION:
STATUS:CONFIRMED
TRANSP:TRANSPARENT
END:VEVENT
END:VCALENDAR
```

The existing `_normalize_rrule_until` function already handles the inverse case (tz-aware `DTSTART` + naive `UNTIL`) but the plain-date/naive-datetime path just returned the rrule string unchanged.

Fix: when dtstart is a date or naive datetime, check whether `UNTIL` is timezone-aware and strip the tzinfo if so. This makes both sides naive, which is what dateutil expects.

Traceback without fix:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/aiohttp/web_protocol.py", line 575, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/web_app.py", line 559, in _handle
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/aiohttp_openmetrics/__init__.py", line 79, in metrics_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/web.py", line 3006, in xandikos_handler
    return await main_app.aiohttp_handler(request, options.route_prefix)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/webdav.py", line 3459, in aiohttp_handler
    response = await self._handle_request(request, environ)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/web.py", line 2503, in _handle_request
    return await super()._handle_request(request, environ)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/webdav.py", line 3410, in _handle_request
    return await do.handle(request, environ, self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/webdav.py", line 2855, in handle
    return await reporter.report(
           ^^^^^^^^^^^^^^^^^^^^^^
    ...<13 lines>...
    )
    ^
  File "/code/xandikos/webdav.py", line 454, in wrapper
    async for resp in req_fn(self, environ, *args, **kwargs):
        responses.append(resp)
  File "/code/xandikos/caldav.py", line 632, in report
    async for href, resource in webdav.traverse_resource(
    ...<14 lines>...
            )
  File "/code/xandikos/webdav.py", line 1694, in traverse_resource
    for child_name, child_resource in members_fn(resource):
                                      ~~~~~~~~~~^^^^^^^^^^
  File "/code/xandikos/web.py", line 1162, in calendar_query
    for name, file, etag in self.store.iter_with_filter(filter=filter):
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/code/xandikos/store/__init__.py", line 439, in _iter_with_filter_indexes
    if filter.check(name, file):
       ~~~~~~~~~~~~^^^^^^^^^^^^
  File "/code/xandikos/icalendar.py", line 1536, in check
    c = file.get_expanded_calendar(time_range.start, time_range.end)
  File "/code/xandikos/icalendar.py", line 1673, in get_expanded_calendar
    return expand_calendar_rrule(self.calendar, start, end)
  File "/code/xandikos/icalendar.py", line 2258, in expand_calendar_rrule
    for expanded in _expand_rrule_component(comp, start, end, exceptions):
                    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/xandikos/icalendar.py", line 2122, in _expand_rrule_component
    rs = rruleset_from_comp(incomp)
  File "/code/xandikos/icalendar.py", line 1910, in rruleset_from_comp
    rrule = dateutil.rrule.rrulestr(rrulestr, dtstart=dtstart)
  File "/usr/lib/python3/dist-packages/dateutil/rrule.py", line 1732, in __call__
    return self._parse_rfc(s, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dateutil/rrule.py", line 1652, in _parse_rfc
    return self._parse_rfc_rrule(lines[0], cache=cache,
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
                                 dtstart=dtstart, ignoretz=ignoretz,
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                 tzinfos=tzinfos)
                                 ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/dateutil/rrule.py", line 1561, in _parse_rfc_rrule
    return rrule(dtstart=dtstart, cache=cache, **rrkwargs)
  File "/usr/lib/python3/dist-packages/dateutil/rrule.py", line 470, in __init__
    raise ValueError(
    ...<2 lines>...
    )
ValueError: RRULE UNTIL values must be specified in UTC when DTSTART is timezone-aware
```

Affects at least Google-exported birthday calendars synced via DAVx5/KOrganizer.