### PR TITLE
Import get_user_identity from dulwich.repo

### DIFF
--- a/xandikos/store/git.py
+++ b/xandikos/store/git.py
@@ -40,7 +40,7 @@ from dulwich.index import (
     locked_index,
 )
 from dulwich.objects import Blob, Commit, Tree
-from dulwich.porcelain import get_user_identity
+from dulwich.repo import get_user_identity
 
 from . import (
     DEFAULT_MIME_TYPE,


### PR DESCRIPTION
Import from the canonical location; dulwich 1.2.10/1.2.11 dropped the dulwich.porcelain re-export.