### PR TITLE
Fall back to full file check for recurring events with a TZID DTSTART

### DIFF
--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -27,7 +27,7 @@ from icalendar.cal import Calendar, Event, Alarm, Todo
 from icalendar.prop import vCategory, vText, vDuration, vDDDTypes
 
 from xandikos import collation as _mod_collation
-from xandikos.store import InvalidFileContents
+from xandikos.store import InsufficientIndexDataError, InvalidFileContents
 
 from xandikos.icalendar import (
     CalendarFilter,
@@ -1008,6 +1008,79 @@ END:VCALENDAR
         }
         self.assertTrue(filter.check_from_indexes("file", indexes))
         self.assertTrue(filter.check("file", self.cal))
+
+    def test_rrule_index_based_filtering_tzid_dst(self):
+        """Recurring event with a TZID DTSTART must not be expanded from the index.
+
+        The index stores DTSTART by its wall-clock value only (the TZID
+        parameter is dropped when the property is serialized), so it comes back
+        as a naive datetime.  A weekly event at 09:05 Europe/Berlin happens at
+        07:05Z in summer but 08:05Z in winter; expanding the naive value would
+        pin every occurrence to the same wall-clock time in UTC and silently
+        move the winter instances by an hour.  For such events the matcher must
+        report insufficient index data so the store falls back to expanding the
+        real file, which keeps the original timezone.
+        """
+        # Only the lines relevant to the bug: a DTSTART/DTEND carrying a
+        # Windows TZID (which icalendar resolves to Europe/Berlin) and a
+        # weekly RRULE.  No VTIMEZONE block is needed for the timezone to
+        # resolve.
+        tzid_rrule = b"""\
+BEGIN:VCALENDAR
+BEGIN:VEVENT
+DTSTART;TZID=W. Europe Standard Time:20250722T090500
+DTEND;TZID=W. Europe Standard Time:20250722T095000
+RRULE:FREQ=WEEKLY;UNTIL=20270720T070500Z;BYDAY=TU
+UID:2a5666700a3972be13eed0a9183cad638dbb0deb32f45b65ba8b1b56c819ba77
+END:VEVENT
+END:VCALENDAR
+"""
+        self.cal = ICalendarFile([tzid_rrule], "text/calendar")
+
+        def make_filter(start, end):
+            filter = CalendarFilter(ZoneInfo("UTC"))
+            filter.filter_subcomponent("VCALENDAR").filter_subcomponent(
+                "VEVENT"
+            ).filter_time_range(start=self._tzify(start), end=self._tzify(end))
+            return filter
+
+        # The store indexes a file by asking the filter which keys it needs
+        # and serializing those properties from the file.
+        winter_hit = make_filter(
+            datetime(2026, 1, 6, 8, 0, 0), datetime(2026, 1, 6, 9, 0, 0)
+        )
+        keys = [key for key_set in winter_hit.index_keys() for key in key_set]
+        indexes = self.cal.get_indexes(keys)
+
+        # The TZID parameter is not part of the indexed value, so DTSTART is
+        # indexed as a naive wall-clock timestamp (no trailing Z).
+        self.assertEqual(
+            indexes["C=VCALENDAR/C=VEVENT/P=DTSTART"], [b"20250722T090500"]
+        )
+
+        # A true winter occurrence: 2026-01-06 09:05 Berlin == 08:05Z (CET).
+        # The index cannot answer this reliably and must defer to the real file.
+        self.assertRaises(
+            InsufficientIndexDataError,
+            winter_hit.check_from_indexes,
+            "file",
+            indexes,
+        )
+        # The authoritative real-file check finds the occurrence.
+        self.assertTrue(winter_hit.check("file", self.cal))
+
+        # The window that would only match if the naive wall-clock value were
+        # expanded in UTC (09:00-10:00Z in winter) is not a real occurrence.
+        winter_ghost = make_filter(
+            datetime(2026, 1, 6, 9, 0, 0), datetime(2026, 1, 6, 10, 0, 0)
+        )
+        self.assertRaises(
+            InsufficientIndexDataError,
+            winter_ghost.check_from_indexes,
+            "file",
+            indexes,
+        )
+        self.assertFalse(winter_ghost.check("file", self.cal))
 
     def test_rrule_index_based_filtering_with_exceptions(self):
         """Test rrule filtering with recurring events that have exception instances."""

--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -580,6 +580,7 @@ class CalendarFilterTests(unittest.TestCase):
                 ["C=VCALENDAR/C=VTODO/P=CREATED"],
                 ["C=VCALENDAR/C=VTODO/P=COMPLETED"],
                 ["C=VCALENDAR/C=VTODO/P=RRULE"],
+                ["C=VCALENDAR/C=VTODO/P=DTSTART/A=TZID"],
                 ["C=VCALENDAR/C=VTODO"],
             ],
         )
@@ -678,6 +679,7 @@ class CalendarFilterTests(unittest.TestCase):
                 ["C=VCALENDAR/C=VEVENT/P=DTEND"],
                 ["C=VCALENDAR/C=VEVENT/P=DURATION"],
                 ["C=VCALENDAR/C=VEVENT/P=RRULE"],
+                ["C=VCALENDAR/C=VEVENT/P=DTSTART/A=TZID"],
                 ["C=VCALENDAR/C=VEVENT"],
             ],
         )
@@ -1010,8 +1012,12 @@ END:VCALENDAR
         self.assertTrue(filter.check("file", self.cal))
 
     def test_rrule_index_based_filtering_tzid_dst(self):
-        """Recurring events with a TZID DTSTART defer to the real file."""
-        # Weekly event at 09:05 Europe/Berlin: 07:05Z in summer, 08:05Z in winter.
+        """Recurring events with a TZID DTSTART expand DST-correctly from the index.
+
+        Uses a Windows TZID (mapped by icalendar to Europe/Berlin) to also cover
+        the resolution path. The event is at 09:05 wall-clock all year, which is
+        07:05Z in summer and 08:05Z in winter.
+        """
         self.cal = ICalendarFile(
             [
                 b"""\
@@ -1041,31 +1047,104 @@ END:VCALENDAR
         keys = [key for key_set in winter_hit.index_keys() for key in key_set]
         indexes = self.cal.get_indexes(keys)
 
-        # DTSTART is indexed as a naive wall-clock value (TZID dropped).
+        # DTSTART is indexed as a naive wall-clock value; the TZID travels
+        # alongside via the A=TZID sub-key. icalendar resolves the Windows
+        # zone name to Europe/Berlin.
         self.assertEqual(
             indexes["C=VCALENDAR/C=VEVENT/P=DTSTART"], [b"20250722T090500"]
         )
-
-        # Real winter occurrence: 09:05 Berlin == 08:05Z. Index defers; real file matches.
-        self.assertRaises(
-            InsufficientIndexDataError,
-            winter_hit.check_from_indexes,
-            "file",
-            indexes,
+        self.assertEqual(
+            indexes["C=VCALENDAR/C=VEVENT/P=DTSTART/A=TZID"], [b"Europe/Berlin"]
         )
+
+        # Real winter occurrence at 08:05Z: index and file agree.
+        self.assertTrue(winter_hit.check_from_indexes("file", indexes))
         self.assertTrue(winter_hit.check("file", self.cal))
 
-        # Ghost window that would match if the naive value were expanded in UTC.
+        # Ghost window that would only match if the naive value were mis-expanded
+        # in UTC. Both paths reject it.
         winter_ghost = make_filter(
             datetime(2026, 1, 6, 9, 0, 0), datetime(2026, 1, 6, 10, 0, 0)
         )
+        self.assertFalse(winter_ghost.check_from_indexes("file", indexes))
+        self.assertFalse(winter_ghost.check("file", self.cal))
+
+        # Summer occurrence at 07:05Z: DST-correct on both paths.
+        summer_hit = make_filter(
+            datetime(2026, 7, 7, 7, 0, 0), datetime(2026, 7, 7, 8, 0, 0)
+        )
+        self.assertTrue(summer_hit.check_from_indexes("file", indexes))
+        self.assertTrue(summer_hit.check("file", self.cal))
+
+    def test_rrule_index_based_filtering_unresolvable_tzid(self):
+        """A recurring event whose TZID isn't in tzdata falls back to the file."""
+        cal = ICalendarFile(
+            [
+                b"""\
+BEGIN:VCALENDAR
+BEGIN:VEVENT
+DTSTART;TZID=Some/Bogus:20250722T090500
+DTEND;TZID=Some/Bogus:20250722T095000
+RRULE:FREQ=WEEKLY;COUNT=5
+UID:bogus-tz
+END:VEVENT
+END:VCALENDAR
+"""
+            ],
+            "text/calendar",
+        )
+        filter = CalendarFilter(ZoneInfo("UTC"))
+        filter.filter_subcomponent("VCALENDAR").filter_subcomponent(
+            "VEVENT"
+        ).filter_time_range(
+            start=self._tzify(datetime(2025, 7, 22, 8, 0, 0)),
+            end=self._tzify(datetime(2025, 7, 22, 10, 0, 0)),
+        )
+        keys = [key for key_set in filter.index_keys() for key in key_set]
+        indexes = cal.get_indexes(keys)
+        self.assertEqual(
+            indexes["C=VCALENDAR/C=VEVENT/P=DTSTART/A=TZID"], [b"Some/Bogus"]
+        )
         self.assertRaises(
             InsufficientIndexDataError,
-            winter_ghost.check_from_indexes,
+            filter.check_from_indexes,
             "file",
             indexes,
         )
-        self.assertFalse(winter_ghost.check("file", self.cal))
+
+    def test_rrule_index_based_filtering_floating_recurring(self):
+        """A genuine floating-time recurring event expands without a TZID."""
+        cal = ICalendarFile(
+            [
+                b"""\
+BEGIN:VCALENDAR
+BEGIN:VEVENT
+DTSTART:20250722T090500
+DTEND:20250722T095000
+RRULE:FREQ=WEEKLY;COUNT=10;BYDAY=TU
+UID:floating-uid
+END:VEVENT
+END:VCALENDAR
+"""
+            ],
+            "text/calendar",
+        )
+        filter = CalendarFilter(ZoneInfo("UTC"))
+        filter.filter_subcomponent("VCALENDAR").filter_subcomponent(
+            "VEVENT"
+        ).filter_time_range(
+            start=self._tzify(datetime(2025, 8, 5, 9, 0, 0)),
+            end=self._tzify(datetime(2025, 8, 5, 10, 0, 0)),
+        )
+        keys = [key for key_set in filter.index_keys() for key in key_set]
+        indexes = cal.get_indexes(keys)
+        # No TZID param on the property, so the sub-index is empty.
+        self.assertEqual(indexes["C=VCALENDAR/C=VEVENT/P=DTSTART/A=TZID"], [])
+        # Index and file agree on the floating expansion.
+        self.assertEqual(
+            filter.check_from_indexes("file", indexes),
+            filter.check("file", cal),
+        )
 
     def test_rrule_index_based_filtering_with_exceptions(self):
         """Test rrule filtering with recurring events that have exception instances."""

--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -27,7 +27,7 @@ from icalendar.cal import Calendar, Event, Alarm, Todo
 from icalendar.prop import vCategory, vText, vDuration, vDDDTypes
 
 from xandikos import collation as _mod_collation
-from xandikos.store import InvalidFileContents
+from xandikos.store import InsufficientIndexDataError, InvalidFileContents
 
 from xandikos.icalendar import (
     CalendarFilter,
@@ -1008,6 +1008,64 @@ END:VCALENDAR
         }
         self.assertTrue(filter.check_from_indexes("file", indexes))
         self.assertTrue(filter.check("file", self.cal))
+
+    def test_rrule_index_based_filtering_tzid_dst(self):
+        """Recurring events with a TZID DTSTART defer to the real file."""
+        # Weekly event at 09:05 Europe/Berlin: 07:05Z in summer, 08:05Z in winter.
+        self.cal = ICalendarFile(
+            [
+                b"""\
+BEGIN:VCALENDAR
+BEGIN:VEVENT
+DTSTART;TZID=W. Europe Standard Time:20250722T090500
+DTEND;TZID=W. Europe Standard Time:20250722T095000
+RRULE:FREQ=WEEKLY;UNTIL=20270720T070500Z;BYDAY=TU
+UID:2a5666700a3972be13eed0a9183cad638dbb0deb32f45b65ba8b1b56c819ba77
+END:VEVENT
+END:VCALENDAR
+"""
+            ],
+            "text/calendar",
+        )
+
+        def make_filter(start, end):
+            filter = CalendarFilter(ZoneInfo("UTC"))
+            filter.filter_subcomponent("VCALENDAR").filter_subcomponent(
+                "VEVENT"
+            ).filter_time_range(start=self._tzify(start), end=self._tzify(end))
+            return filter
+
+        winter_hit = make_filter(
+            datetime(2026, 1, 6, 8, 0, 0), datetime(2026, 1, 6, 9, 0, 0)
+        )
+        keys = [key for key_set in winter_hit.index_keys() for key in key_set]
+        indexes = self.cal.get_indexes(keys)
+
+        # DTSTART is indexed as a naive wall-clock value (TZID dropped).
+        self.assertEqual(
+            indexes["C=VCALENDAR/C=VEVENT/P=DTSTART"], [b"20250722T090500"]
+        )
+
+        # Real winter occurrence: 09:05 Berlin == 08:05Z. Index defers; real file matches.
+        self.assertRaises(
+            InsufficientIndexDataError,
+            winter_hit.check_from_indexes,
+            "file",
+            indexes,
+        )
+        self.assertTrue(winter_hit.check("file", self.cal))
+
+        # Ghost window that would match if the naive value were expanded in UTC.
+        winter_ghost = make_filter(
+            datetime(2026, 1, 6, 9, 0, 0), datetime(2026, 1, 6, 10, 0, 0)
+        )
+        self.assertRaises(
+            InsufficientIndexDataError,
+            winter_ghost.check_from_indexes,
+            "file",
+            indexes,
+        )
+        self.assertFalse(winter_ghost.check("file", self.cal))
 
     def test_rrule_index_based_filtering_with_exceptions(self):
         """Test rrule filtering with recurring events that have exception instances."""

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -943,6 +943,23 @@ class ComponentTimeRangeMatcher:
                 )
             return False
 
+        # A DTSTART carrying a TZID parameter is serialized into the index by
+        # its wall-clock value alone (ICalendarFile._get_index calls
+        # vDDDTypes.to_ical(), which drops the TZID parameter), so it appears
+        # here as a naive datetime. Expanding the RRULE from that naive value
+        # loses the timezone, and the naive occurrences no longer identify the
+        # correct instants: the sample event recurs at 09:05 Europe/Berlin,
+        # i.e. 07:05Z in summer but 08:05Z in winter across the DST boundary.
+        # A naive index value cannot be distinguished from a genuine floating
+        # time, so defer to the authoritative expansion of the real file.
+        # Genuine UTC datetimes keep their trailing Z and remain timezone-aware
+        # here; UTC has no DST, so expanding those directly is safe.
+        if isinstance(dtstart_parsed, datetime) and dtstart_parsed.tzinfo is None:
+            raise InsufficientIndexDataError(
+                "recurring event with a naive DTSTART cannot be reliably "
+                "expanded from index data; falling back to full file check"
+            )
+
         # Get component handler for testing occurrences
         try:
             component_handler = self.component_handlers[self.comp]

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -24,7 +24,7 @@ from collections.abc import Iterable
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from collections.abc import Callable
 from typing import Any, Protocol, cast, overload, runtime_checkable
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import dateutil.rrule
 from icalendar.cal import Calendar, Component, Timezone
@@ -918,6 +918,14 @@ class ComponentTimeRangeMatcher:
 
             # Parse DTSTART and create rrule
             dtstart_parsed = vDDDTypes.from_ical(dtstart_str)
+            # A DTSTART with a TZID loses its timezone through the index (the
+            # parameter is dropped when the value is serialized). Reattach it
+            # from the companion A=TZID sub-index; without a timezone, DST
+            # boundaries would shift every occurrence by an hour.
+            if isinstance(dtstart_parsed, datetime) and dtstart_parsed.tzinfo is None:
+                dtstart_parsed = _attach_indexed_tzid(
+                    dtstart_parsed, indexes["P=DTSTART/A=TZID"]
+                )
             # Normalize UNTIL to be UTC if dtstart is timezone-aware
             rrule_str = _normalize_rrule_until(rrule_str, dtstart_parsed)
             rrule = dateutil.rrule.rrulestr(rrule_str, dtstart=dtstart_parsed)
@@ -942,15 +950,6 @@ class ComponentTimeRangeMatcher:
                     "Failed to parse RRULE in time-range filter (UID=%s): %s", uid, e
                 )
             return False
-
-        # The index drops the TZID parameter when serializing DTSTART, so a
-        # timezone-aware start comes back naive and can no longer be expanded
-        # across a DST boundary. Defer to the real file, which keeps its
-        # VTIMEZONE. UTC values keep their trailing Z and remain aware here.
-        if isinstance(dtstart_parsed, datetime) and dtstart_parsed.tzinfo is None:
-            raise InsufficientIndexDataError(
-                "recurring event with naive DTSTART; falling back to full file"
-            )
 
         # Get component handler for testing occurrences
         try:
@@ -1012,7 +1011,13 @@ class ComponentTimeRangeMatcher:
                 if isinstance(dtstart_parsed, datetime) and isinstance(
                     end_parsed_val, datetime
                 ):
-                    return end_parsed_val - dtstart_parsed
+                    # DTEND is parsed from the index without its TZID, so it
+                    # may be naive while DTSTART has been reattached to one.
+                    # Subtract on wall-clock values to sidestep the mismatch;
+                    # for the RRULE occurrence window this is what we want.
+                    return end_parsed_val.replace(tzinfo=None) - dtstart_parsed.replace(
+                        tzinfo=None
+                    )
         return None
 
     def _get_occurrences_in_range(self, rrule, dtstart_parsed, query_start, query_end):
@@ -1120,7 +1125,12 @@ class ComponentTimeRangeMatcher:
             props = ["TRIGGER", "DURATION", "REPEAT"]
         else:
             props = self.all_props
-        return [["P=" + prop] for prop in props]
+        keys = [["P=" + prop] for prop in props]
+        # DTSTART's TZID travels alongside via a sub-key so RRULE expansion
+        # can reconstruct the timezone and stay DST-correct.
+        if "DTSTART" in props:
+            keys.append(["P=DTSTART/A=TZID"])
+        return keys
 
 
 class TextMatcher:
@@ -1595,6 +1605,51 @@ class CalendarFilter(Filter):
         return f"{self.__class__.__name__}({self.children!r})"
 
 
+def _index_property_parameter(prop, param_name: str) -> bytes | None:
+    """Extract a property parameter value for indexing.
+
+    For TZID on a datetime-valued property, prefer the tzinfo icalendar
+    already resolved (a real ZoneInfo, including Windows-name mappings like
+    "W. Europe Standard Time" -> Europe/Berlin) so the reader can rebuild
+    the timezone without needing the file's VTIMEZONE.
+    """
+    if (
+        param_name == "TZID"
+        and isinstance(prop, TimeProperty)
+        and isinstance(prop.dt, datetime)
+        and prop.dt.tzinfo is not None
+    ):
+        return str(prop.dt.tzinfo).encode("utf-8")
+    try:
+        raw = prop.params[param_name]
+    except KeyError:
+        return None
+    return raw if isinstance(raw, bytes) else str(raw).encode("utf-8")
+
+
+def _attach_indexed_tzid(dt: datetime, tzid_values: list[bytes | bool]) -> datetime:
+    """Reattach a TZID from the index to a naive datetime.
+
+    Empty ``tzid_values`` means the property had no TZID (floating time), in
+    which case the datetime stays naive.
+    """
+    if not tzid_values:
+        return dt
+    tzid_bytes = tzid_values[0]
+    assert isinstance(tzid_bytes, bytes)
+    tzid = tzid_bytes.decode("utf-8")
+    try:
+        tzinfo = ZoneInfo(tzid)
+    except ZoneInfoNotFoundError:
+        # Unresolvable TZID. The file may still expand via its VTIMEZONE, so
+        # hand off rather than pick a wrong offset.
+        raise InsufficientIndexDataError(
+            f"recurring event with unresolvable indexed TZID {tzid!r}; "
+            "falling back to full file"
+        )
+    return dt.replace(tzinfo=tzinfo)
+
+
 class ICalendarFile(File):
     """Handle for ICalendar files."""
 
@@ -1750,7 +1805,6 @@ class ICalendarFile(File):
             if not segments:
                 yield True
             elif segments[0].startswith("P="):
-                assert len(segments) == 1
                 prop_name = segments[0][2:]
                 try:
                     p = c[prop_name]
@@ -1758,6 +1812,12 @@ class ICalendarFile(File):
                     pass
                 else:
                     if p is not None:
+                        if len(segments) == 2 and segments[1].startswith("A="):
+                            value = _index_property_parameter(p, segments[1][2:])
+                            if value is not None:
+                                yield value
+                            continue
+                        assert len(segments) == 1, f"segments: {segments!r}"
                         ical = p.to_ical()
                         # Special handling for VALARM TRIGGER property
                         if (

--- a/xandikos/icalendar.py
+++ b/xandikos/icalendar.py
@@ -943,6 +943,15 @@ class ComponentTimeRangeMatcher:
                 )
             return False
 
+        # The index drops the TZID parameter when serializing DTSTART, so a
+        # timezone-aware start comes back naive and can no longer be expanded
+        # across a DST boundary. Defer to the real file, which keeps its
+        # VTIMEZONE. UTC values keep their trailing Z and remain aware here.
+        if isinstance(dtstart_parsed, datetime) and dtstart_parsed.tzinfo is None:
+            raise InsufficientIndexDataError(
+                "recurring event with naive DTSTART; falling back to full file"
+            )
+
         # Get component handler for testing occurrences
         try:
             component_handler = self.component_handlers[self.comp]


### PR DESCRIPTION
I ran into this with a calendar that syncs from Outlook/Office 365 into Xandikos via vdirsyncer. In KOrganizer only the one-off events showed up; every weekly/monthly series was missing. After some digging it turned out the series are there, they just get dropped once the collection is indexed.

The short version: the index stores DTSTART by its wall-clock value and throws away the TZID parameter, so it comes back as a naive datetime. When the RRULE is expanded from that naive value the timezone is gone, and the occurrences end up at the wrong instant as soon as DST is involved.

## Reproducing it

Here's the actual event that sent me down this path (a weekly status meeting at 09:05 Europe/Berlin):

```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//Microsoft Corporation//Outlook 16.0 MIMEDIR//EN
BEGIN:VTIMEZONE
TZID:W. Europe Standard Time
BEGIN:STANDARD
DTSTART:16011028T030000
RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
TZOFFSETFROM:+0200
TZOFFSETTO:+0100
END:STANDARD
BEGIN:DAYLIGHT
DTSTART:16010325T020000
RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3
TZOFFSETFROM:+0100
TZOFFSETTO:+0200
END:DAYLIGHT
END:VTIMEZONE
BEGIN:VEVENT
SUMMARY:Weekly - Status Update Software Dev
DTSTART;TZID=W. Europe Standard Time:20250722T090500
DTEND;TZID=W. Europe Standard Time:20250722T095000
RRULE:FREQ=WEEKLY;UNTIL=20270720T070500Z;INTERVAL=1;BYDAY=TU;WKST=MO
UID:2a5666700a3972be13eed0a9183cad638dbb0deb32f45b65ba8b1b56c819ba77
END:VEVENT
END:VCALENDAR
```

Do a calendar-query with a time-range over one of the winter occurrences, say Tuesday 2026-01-06. Before the collection is indexed the event comes back; once it's indexed it's gone (or shows up an hour off, depending on the exact window).

## Where it breaks

`ICalendarFile._get_index()` serializes each property with `vDDDTypes.to_ical()`. For a DTSTART that has a TZID, that call only gives you the wall-clock value and quietly drops the parameter:

```
DTSTART;TZID=W. Europe Standard Time:20250722T090500   ->   b"20250722T090500"
```

So when a time-range query is served from the index, `ComponentTimeRangeMatcher._match_indexes_with_rrule()` reads that back with `vDDDTypes.from_ical()`, gets a naive datetime, and expands the RRULE from it. With no timezone attached, every occurrence gets pinned to the same wall-clock time, which doesn't line up with the real instants once you cross a DST boundary:

- 2025-07-22 (summer, CEST): really 07:05Z, index thinks 09:05
- 2026-01-06 (winter, CET): really 08:05Z, index thinks 09:05

That's why the event both disappears from the window where it actually is (08:05Z in winter) and shows up in a window where it isn't (09:05Z).

I briefly tried normalizing the indexed value to UTC instead, but that doesn't hold up: the event is 09:05 Berlin all year round, so its UTC offset changes with DST. A single UTC timestamp expands at one fixed offset and is wrong for half the year. The timezone really has to make it into the expansion, and the only thing that has it is the original file (which still carries its VTIMEZONE). `get_expanded_calendar()` expands the untouched component, so it gets this right.

## The change

A naive value in the index is genuinely ambiguous — it might be a real floating-time event, or a TZID event that lost its zone on the way into the index. There's no way to tell from the index alone, and neither can be expanded correctly across DST without the timezone. So for a recurring event with a naive DTSTART I bail out and let the store fall back to the real file, which expands from the timezone-aware component and is DST-correct:

```python
if isinstance(dtstart_parsed, datetime) and dtstart_parsed.tzinfo is None:
    raise InsufficientIndexDataError(
        "recurring event with a naive DTSTART cannot be reliably "
        "expanded from index data; falling back to full file check"
    )
```

Genuine UTC datetimes are left alone: they keep their trailing `Z`, still parse as timezone-aware, and get expanded straight from the index like before. UTC has no DST so that path was never wrong. The guard only kicks in for the naive case.

## Test

`test_rrule_index_based_filtering_tzid_dst` uses the event above and checks:

- the indexed DTSTART really is the naive `b"20250722T090500"` (this is the
  behaviour that causes the bug);
- for the real winter window (2026-01-06 08:00-09:00Z) `check_from_indexes()`
  raises `InsufficientIndexDataError` and the real-file `check()` returns
  true;
- for the ghost window (2026-01-06 09:00-10:00Z) `check_from_indexes()` again
  raises and `check()` returns false.