### PR TITLE
Name unsupported push triggers in error message

### DIFF
--- a/tests/test_webdav_push.py
+++ b/tests/test_webdav_push.py
@@ -123,10 +123,21 @@ class ParsePushRegisterTests(unittest.TestCase):
 
     def test_no_supported_trigger(self):
         triggers = '<unknown-trigger xmlns="https://bitfire.at/webdav-push"/>'
-        with self.assertRaises(webdav_push.NoSupportedTriggerError):
+        with self.assertRaises(webdav_push.NoSupportedTriggerError) as cm:
             webdav_push.parse_push_register(
                 _parse(_push_register_xml(triggers_xml=triggers))
             )
+        self.assertIn(
+            "{https://bitfire.at/webdav-push}unknown-trigger", str(cm.exception)
+        )
+
+    def test_no_trigger_element(self):
+        body = _push_register_xml(triggers_xml="")
+        # Strip the empty <trigger> wrapper so no trigger element is present.
+        body = body.replace(b"<trigger></trigger>", b"")
+        with self.assertRaises(webdav_push.NoSupportedTriggerError) as cm:
+            webdav_push.parse_push_register(_parse(body))
+        self.assertEqual("no supported trigger requested", str(cm.exception))
 
     def test_expires_parsed(self):
         sub, expires = webdav_push.parse_push_register(

--- a/xandikos/webdav_push.py
+++ b/xandikos/webdav_push.py
@@ -409,8 +409,12 @@ def parse_push_register(root) -> tuple[Subscription, datetime | None]:
             f"auth-secret is not valid base64url: {exc}"
         ) from exc
 
-    triggers = _parse_triggers(root)
+    triggers, unsupported = _parse_triggers(root)
     if not triggers:
+        if unsupported:
+            raise NoSupportedTriggerError(
+                "no supported trigger requested; unsupported: " + ", ".join(unsupported)
+            )
         raise NoSupportedTriggerError("no supported trigger requested")
 
     expires_el = root.find("{%s}expires" % NAMESPACE)
@@ -434,11 +438,18 @@ def parse_push_register(root) -> tuple[Subscription, datetime | None]:
     return sub, expires
 
 
-def _parse_triggers(root) -> list[Trigger]:
+def _parse_triggers(root) -> tuple[list[Trigger], list[str]]:
+    """Parse trigger children.
+
+    Returns ``(supported, unsupported)``. ``unsupported`` holds the tag
+    names of trigger children we don't understand, so the caller can
+    surface them in the error response.
+    """
     triggers: list[Trigger] = []
+    unsupported: list[str] = []
     trigger_el = root.find("{%s}trigger" % NAMESPACE)
     if trigger_el is None:
-        return triggers
+        return triggers, unsupported
     for child in trigger_el:
         if child.tag == "{%s}content-update" % NAMESPACE:
             depth_el = child.find("{DAV:}depth")
@@ -455,8 +466,9 @@ def _parse_triggers(root) -> list[Trigger]:
             triggers.append(
                 Trigger(kind=TRIGGER_PROPERTY_UPDATE, depth=depth, props=props)
             )
-        # Unknown trigger children are ignored.
-    return triggers
+        else:
+            unsupported.append(child.tag)
+    return triggers, unsupported
 
 
 def build_push_message_xml(


### PR DESCRIPTION
Helps diagnose push-register rejections (e.g. issue #716) by logging which trigger tag the client sent instead of the generic "no supported trigger requested".