### PR TITLE
Implement the RFC 5842 DAV:resource-id property

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+0.4.6	UNRELEASED
+
+ * Implement the RFC 5842 ``DAV:resource-id`` property. Calendar and
+   addressbook object resources derive their identifier from the file
+   UID; collections auto-generate and persist a UUID. (Jelmer Vernooĳ,
+   #89)
+
 0.4.5	2026-07-21
 
  * Implement the RFC 3744 ``principal-property-search`` REPORT, the

--- a/notes/dav-compliance.rst
+++ b/notes/dav-compliance.rst
@@ -518,11 +518,14 @@ Other Notable Specifications
 rfc5842.txt (WebDAV BIND)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Not supported.
+Partial: only the ``DAV:resource-id`` property is implemented.
 
 - BIND method [not supported]
 - UNBIND method [not supported]
 - REBIND method [not supported]
+- ``DAV:resource-id`` property [supported - urn:uuid: identifiers,
+  derived from the file UID for calendar/addressbook object resources
+  and auto-generated and persisted per collection]
 
 rfc8144.txt (Prefer Header)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -78,6 +78,31 @@ class CalendarCollectionTests(unittest.TestCase):
         self.cal.set_calendar_color("#aabbcc")
         self.assertEqual("#aabbcc", self.cal.get_calendar_color())
 
+    def test_resource_id_generated_and_persisted(self):
+        """Collections auto-generate and persist a stable resource-id."""
+        import uuid as uuid_mod
+
+        first = asyncio.run(self.cal.get_resource_id())
+        self.assertTrue(first.startswith("urn:uuid:"))
+        # Value parses as a UUID and is idempotent across calls.
+        uuid_mod.UUID(first[len("urn:uuid:") :])
+        second = asyncio.run(self.cal.get_resource_id())
+        self.assertEqual(first, second)
+        # Persisted to the store so it survives a fresh collection view.
+        stored = self.store.get_resource_id()
+        self.assertEqual(f"urn:uuid:{stored}", first)
+
+    def test_object_resource_id_from_uid(self):
+        """Object resources derive resource-id from their file UID."""
+        (name, _etag) = self.store.import_one(
+            "foo.ics", "text/calendar", [EXAMPLE_VCALENDAR1]
+        )
+        member = self.cal.get_member(name)
+        rid = asyncio.run(member.get_resource_id())
+        # The UID in EXAMPLE_VCALENDAR1 is itself a UUID, so it's used
+        # directly under the urn:uuid: scheme.
+        self.assertEqual("urn:uuid:bdc22720-b9e1-42c9-89c2-a85405d8fbff", rid)
+
     def test_get_supported_calendar_components(self):
         self.assertEqual(
             ["VEVENT", "VTODO", "VJOURNAL", "VFREEBUSY", "VAVAILABILITY"],
@@ -186,6 +211,43 @@ class CalendarCollectionTests(unittest.TestCase):
 
         self.assertEqual(["200 OK"], codes)
         self.assertEqual(b"".join([commit_hash, b"\t", default_branch, b"\n"]), body)
+
+    def test_propfind_resource_id(self):
+        """PROPFIND for {DAV:}resource-id returns a urn:uuid: href."""
+        from io import BytesIO
+        from wsgiref.util import setup_testing_defaults
+
+        self.store.import_one("foo.ics", "text/calendar", [EXAMPLE_VCALENDAR1])
+        app = XandikosApp(self.backend, "user")
+
+        body = (
+            b'<?xml version="1.0" encoding="utf-8" ?>'
+            b'<D:propfind xmlns:D="DAV:">'
+            b"<D:prop><D:resource-id/></D:prop>"
+            b"</D:propfind>"
+        )
+        environ = {
+            "PATH_INFO": "/c/foo.ics",
+            "REQUEST_METHOD": "PROPFIND",
+            "CONTENT_TYPE": "application/xml",
+            "CONTENT_LENGTH": str(len(body)),
+            "HTTP_DEPTH": "0",
+            "wsgi.input": BytesIO(body),
+        }
+        setup_testing_defaults(environ)
+
+        codes = []
+
+        def start_response(code, _headers):
+            codes.append(code)
+
+        resp = b"".join(app(environ, start_response))
+
+        self.assertEqual(["207 Multi-Status"], codes)
+        self.assertIn(
+            b"<ns0:href>urn:uuid:bdc22720-b9e1-42c9-89c2-a85405d8fbff</ns0:href>",
+            resp,
+        )
 
     def test_calendar_availability_not_set(self):
         """Test getting availability when none is set raises KeyError."""

--- a/tests/test_webdav.py
+++ b/tests/test_webdav.py
@@ -3098,6 +3098,66 @@ class PropertyRemovalTests(unittest.TestCase):
         self.assertEqual(resource.resource_types, [])
 
 
+class ResourceIdFromNameTests(unittest.TestCase):
+    """Deterministic mapping of arbitrary names to ``urn:uuid:`` URIs."""
+
+    def test_plain_uuid(self):
+        self.assertEqual(
+            "urn:uuid:12345678-1234-5678-1234-567812345678",
+            webdav._resource_id_from_name("12345678-1234-5678-1234-567812345678"),
+        )
+
+    def test_urn_uuid_prefixed(self):
+        self.assertEqual(
+            "urn:uuid:12345678-1234-5678-1234-567812345678",
+            webdav._resource_id_from_name(
+                "urn:uuid:12345678-1234-5678-1234-567812345678"
+            ),
+        )
+
+    def test_non_uuid_stable(self):
+        first = webdav._resource_id_from_name("my-vevent-uid")
+        second = webdav._resource_id_from_name("my-vevent-uid")
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("urn:uuid:"))
+
+    def test_non_uuid_distinct(self):
+        self.assertNotEqual(
+            webdav._resource_id_from_name("uid-a"),
+            webdav._resource_id_from_name("uid-b"),
+        )
+
+
+class ResourceIdPropertyTests(unittest.TestCase):
+    """DAV:resource-id property value handling (RFC 5842 §3.1)."""
+
+    def test_returns_href_child(self):
+        class TestResource(Resource):
+            async def get_resource_id(self):
+                return "urn:uuid:12345678-1234-5678-1234-567812345678"
+
+        prop = webdav.ResourceIdProperty()
+        el = ET.Element(prop.name)
+
+        async def run():
+            await prop.get_value("/x", TestResource(), el, {})
+
+        asyncio.run(run())
+        [child] = list(el)
+        self.assertEqual("{DAV:}href", child.tag)
+        self.assertEqual("urn:uuid:12345678-1234-5678-1234-567812345678", child.text)
+
+    def test_missing_raises(self):
+        prop = webdav.ResourceIdProperty()
+        el = ET.Element(prop.name)
+
+        async def run():
+            await prop.get_value("/x", Resource(), el, {})
+
+        with self.assertRaises(KeyError):
+            asyncio.run(run())
+
+
 class SplitDestinationPathTests(unittest.TestCase):
     """MOVE/COPY destinations are split before decoding, like request paths."""
 

--- a/xandikos/store/__init__.py
+++ b/xandikos/store/__init__.py
@@ -643,6 +643,22 @@ class Store:
         """Set the color code for this store."""
         raise NotImplementedError(self.set_color)
 
+    def get_resource_id(self) -> str:
+        """Get the persisted DAV:resource-id UUID for this store.
+
+        Returns: UUID string
+        Raises: KeyError if not set
+        """
+        raise NotImplementedError(self.get_resource_id)
+
+    def set_resource_id(self, resource_id: str) -> None:
+        """Persist the DAV:resource-id UUID for this store.
+
+        Args:
+          resource_id: UUID string
+        """
+        raise NotImplementedError(self.set_resource_id)
+
     def iter_changes(
         self, old_ctag: str, new_ctag: str
     ) -> Iterator[tuple[str, str, str, str]]:

--- a/xandikos/store/config.py
+++ b/xandikos/store/config.py
@@ -195,6 +195,22 @@ class CollectionMetadata:
         """
         raise NotImplementedError(self.set_addressbook_home_set)
 
+    def get_resource_id(self) -> str:
+        """Get the persisted DAV:resource-id UUID for this collection.
+
+        Returns: UUID string
+        Raises: KeyError if not set
+        """
+        raise NotImplementedError(self.get_resource_id)
+
+    def set_resource_id(self, resource_id: str) -> None:
+        """Persist the DAV:resource-id UUID for this collection.
+
+        Args:
+            resource_id: UUID string, or None to unset
+        """
+        raise NotImplementedError(self.set_resource_id)
+
 
 class FileBasedCollectionMetadata(CollectionMetadata):
     """Metadata for a configuration."""
@@ -388,3 +404,15 @@ class FileBasedCollectionMetadata(CollectionMetadata):
         self._set_principal_option(
             "addressbook-home-set", joined, "Set addressbook-home-set."
         )
+
+    def get_resource_id(self):
+        if not self._configparser.has_option("DEFAULT", "resource-id"):
+            raise KeyError
+        return self._configparser["DEFAULT"]["resource-id"]
+
+    def set_resource_id(self, resource_id):
+        if resource_id is not None:
+            self._configparser["DEFAULT"]["resource-id"] = resource_id
+        else:
+            del self._configparser["DEFAULT"]["resource-id"]
+        self._save("Set resource-id.")

--- a/xandikos/store/git.py
+++ b/xandikos/store/git.py
@@ -138,6 +138,18 @@ class RepoCollectionMetadata(CollectionMetadata):
             config.remove(b"xandikos", b"color")
         self._write_config(config)
 
+    def get_resource_id(self):
+        config = self._get_config()
+        resource_id = config.get(b"xandikos", b"resource-id")
+        if resource_id in (None, b""):
+            raise KeyError
+        return resource_id.decode(DEFAULT_ENCODING)
+
+    def set_resource_id(self, resource_id):
+        config = self._get_config()
+        config.set(b"xandikos", b"resource-id", resource_id.encode(DEFAULT_ENCODING))
+        self._write_config(config)
+
     def _write_config(self, config):
         f = BytesIO()
         config.write_to_file(f)
@@ -595,6 +607,14 @@ class GitStore(Store):
     def set_color(self, color):
         """Set the color code for this store."""
         self.config.set_color(color)
+
+    def get_resource_id(self):
+        """Get the persisted DAV:resource-id UUID."""
+        return self.config.get_resource_id()
+
+    def set_resource_id(self, resource_id):
+        """Persist the DAV:resource-id UUID."""
+        self.config.set_resource_id(resource_id)
 
     def get_source_url(self):
         """Get source URL."""

--- a/xandikos/store/memory.py
+++ b/xandikos/store/memory.py
@@ -50,6 +50,7 @@ class MemoryStore(Store):
         self._comment = None
         self._color = None
         self._type: str | None = None
+        self._resource_id: str | None = None
 
     def _generate_etag(self) -> str:
         """Generate a unique etag."""
@@ -202,6 +203,16 @@ class MemoryStore(Store):
     def set_color(self, color: str) -> None:
         """Set color (no-op for memory store)."""
         self._color = color
+
+    def get_resource_id(self) -> str:
+        """Get the persisted DAV:resource-id UUID."""
+        if self._resource_id is None:
+            raise KeyError
+        return self._resource_id
+
+    def set_resource_id(self, resource_id: str) -> None:
+        """Persist the DAV:resource-id UUID."""
+        self._resource_id = resource_id
 
     def iter_changes(self, old_ctag: str, new_ctag: str):
         """Get changes between versions (not implemented for memory store)."""

--- a/xandikos/store/vdir.py
+++ b/xandikos/store/vdir.py
@@ -378,6 +378,17 @@ class VdirStore(Store):
         assert color.startswith("#")
         self._write_metadata("color", color)
 
+    def get_resource_id(self):
+        """Get the persisted DAV:resource-id UUID."""
+        resource_id = self._read_metadata("resource-id")
+        if resource_id is None:
+            raise KeyError
+        return resource_id
+
+    def set_resource_id(self, resource_id):
+        """Persist the DAV:resource-id UUID."""
+        self._write_metadata("resource-id", resource_id)
+
     def get_source_url(self):
         """Get source URL."""
         return self._read_metadata("source")

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -35,6 +35,7 @@ import posixpath
 import shutil
 import socket
 import urllib.parse
+import uuid
 from collections.abc import Iterable, Iterator
 from email.utils import parseaddr
 from dulwich.web import make_wsgi_chain
@@ -347,6 +348,14 @@ class ObjectResource(webdav.Resource):
         assert isinstance(cal, Calendar)
         signature = itip.extract_scheduling_signature(cal)
         return create_strong_etag(signature.hex())
+
+    async def get_resource_id(self) -> str:
+        file = await self.get_file()
+        try:
+            uid = file.get_uid()
+        except (NotImplementedError, KeyError):
+            raise KeyError
+        return webdav._resource_id_from_name(uid)
 
 
 async def _run_change_listener(awaitable) -> None:
@@ -667,6 +676,17 @@ class StoreBasedCollection:
 
     def set_refreshrate(self, value):
         self.store.config.set_refreshrate(value)
+
+    async def get_resource_id(self) -> str:
+        try:
+            resource_id = self.store.get_resource_id()
+        except (KeyError, NotImplementedError):
+            resource_id = str(uuid.uuid4())
+            try:
+                self.store.set_resource_id(resource_id)
+            except NotImplementedError:
+                pass
+        return f"urn:uuid:{resource_id}"
 
 
 class Collection(StoreBasedCollection, webdav.Collection):
@@ -2487,6 +2507,7 @@ class XandikosApp(webdav.WebDAVApp):
                 webdav.GetLastModifiedProperty(),
                 timezones.TimezoneServiceSetProperty([]),
                 webdav.AddMemberProperty(),
+                webdav.ResourceIdProperty(),
                 caldav.ScheduleCalendarTransparencyProperty(),
                 scheduling.ScheduleDefaultCalendarURLProperty(),
                 caldav.MaxInstancesProperty(),

--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -33,6 +33,7 @@ from logging import getLogger
 import os
 import posixpath
 import urllib.parse
+import uuid
 from collections.abc import AsyncIterable, Callable, Iterable, Iterator, Sequence
 from datetime import datetime
 from wsgiref.util import request_uri
@@ -47,6 +48,27 @@ logger = getLogger("xandikos")
 DEFAULT_ENCODING = "utf-8"
 COLLECTION_RESOURCE_TYPE = "{DAV:}collection"
 PRINCIPAL_RESOURCE_TYPE = "{DAV:}principal"
+
+# Namespace UUID for deriving stable urn:uuid: values from arbitrary
+# identifier strings (RFC 4122 §4.3, RFC 5842 §3.1).
+_RESOURCE_ID_NAMESPACE = uuid.UUID("cbe1cd76-b0c8-46d7-9c8a-1f6bd6c8a7f2")
+
+
+def _resource_id_from_name(name: str) -> str:
+    """Return a ``urn:uuid:`` URI derived from a stable name.
+
+    If ``name`` already parses as a UUID (with or without a ``urn:uuid:``
+    prefix) it is used directly; otherwise a deterministic UUIDv5 is
+    generated under a xandikos-specific namespace, so repeated calls
+    with the same name always return the same URI.
+    """
+    candidate = name
+    if candidate.startswith("urn:uuid:"):
+        candidate = candidate[len("urn:uuid:") :]
+    try:
+        return "urn:uuid:" + str(uuid.UUID(candidate))
+    except ValueError:
+        return "urn:uuid:" + str(uuid.uuid5(_RESOURCE_ID_NAMESPACE, name))
 
 
 PropStatus = collections.namedtuple(
@@ -691,6 +713,17 @@ class Resource:
         """
         raise NotImplementedError(self.get_quota_available_bytes)
 
+    async def get_resource_id(self) -> str:
+        """Return a URI identifying this resource (RFC 5842).
+
+        The value is a URI in a scheme that guarantees uniqueness across
+        all resources for all time (typically ``urn:uuid:``). Immutable
+        for the lifetime of the resource.
+
+        :raise KeyError: if no stable identifier is available
+        """
+        raise KeyError
+
 
 class Property:
     """Handler for listing, retrieving and updating DAV Properties."""
@@ -893,6 +926,25 @@ class AddMemberProperty(Property):
     async def get_value(self, href, resource, el, environ):
         # Support POST against collection URL
         el.append(create_href(".", href))
+
+
+class ResourceIdProperty(Property):
+    """Provides {DAV:}resource-id.
+
+    https://tools.ietf.org/html/rfc5842, section 3.1
+
+    Contains a URI (typically ``urn:uuid:``) that uniquely identifies a
+    resource across all bindings and across time.
+    """
+
+    name = "{DAV:}resource-id"
+    resource_type = None
+    in_allprops = False
+    live = True
+
+    async def get_value(self, href, resource, el, environ):
+        resource_id = await resource.get_resource_id()
+        ET.SubElement(el, "{DAV:}href").text = resource_id
 
 
 class GetLastModifiedProperty(Property):


### PR DESCRIPTION
Calendar and addressbook object resources derive their identifier from the file UID (parsed as a UUID when possible, otherwise via UUIDv5 under a xandikos-specific namespace). Collections auto-generate a UUIDv4 and persist it in the store config so it remains stable across restarts and renames.

Closes #89