### PR TITLE
Support calendar-proxy-{read,write}-for on principals

### DIFF
--- a/tests/test_caldav.py
+++ b/tests/test_caldav.py
@@ -1488,3 +1488,177 @@ class ExtractFreebusyDeclinedTests(unittest.TestCase):
         comp = self._comp("DECLINED")
         result = extract_freebusy(comp, self._tzify)
         self.assertIsNotNone(result)
+
+
+class CalendarProxyReadForPropertyTests(unittest.TestCase):
+    """Tests for CalendarProxyReadForProperty."""
+
+    def test_property_name(self):
+        prop = caldav.CalendarProxyReadForProperty()
+        self.assertEqual(
+            "{http://calendarserver.org/ns/}calendar-proxy-read-for", prop.name
+        )
+
+    def test_property_attributes(self):
+        prop = caldav.CalendarProxyReadForProperty()
+        self.assertFalse(prop.in_allprops)
+        self.assertTrue(prop.live)
+        self.assertEqual("{DAV:}principal", prop.resource_type)
+
+    def test_get_value_emits_hrefs(self):
+        import asyncio
+
+        async def run_test():
+            prop = caldav.CalendarProxyReadForProperty()
+
+            class MockResource:
+                def get_calendar_proxy_read_for(self):
+                    return ["/principals/alice/", "/principals/bob/"]
+
+            el = ET.Element("test")
+            await prop.get_value("/principals/user1/", MockResource(), el, {})
+            hrefs = [h.text for h in el.findall("{DAV:}href")]
+            self.assertEqual(["/principals/alice/", "/principals/bob/"], hrefs)
+
+        asyncio.run(run_test())
+
+    def test_get_value_empty(self):
+        import asyncio
+
+        async def run_test():
+            prop = caldav.CalendarProxyReadForProperty()
+
+            class MockResource:
+                def get_calendar_proxy_read_for(self):
+                    return []
+
+            el = ET.Element("test")
+            await prop.get_value("/principals/user1/", MockResource(), el, {})
+            self.assertEqual([], el.findall("{DAV:}href"))
+
+        asyncio.run(run_test())
+
+    def test_set_value_extracts_hrefs(self):
+        import asyncio
+
+        async def run_test():
+            prop = caldav.CalendarProxyReadForProperty()
+            captured: list[list[str]] = []
+
+            class MockResource:
+                def set_calendar_proxy_read_for(self, hrefs):
+                    captured.append(hrefs)
+
+            el = ET.Element(prop.name)
+            ET.SubElement(el, "{DAV:}href").text = "/principals/alice/"
+            ET.SubElement(el, "{DAV:}href").text = "/principals/bob/"
+
+            await prop.set_value("/principals/user1/", MockResource(), el)
+            self.assertEqual([["/principals/alice/", "/principals/bob/"]], captured)
+
+        asyncio.run(run_test())
+
+    def test_set_value_remove_clears(self):
+        import asyncio
+
+        async def run_test():
+            prop = caldav.CalendarProxyReadForProperty()
+            captured: list[list[str]] = []
+
+            class MockResource:
+                def set_calendar_proxy_read_for(self, hrefs):
+                    captured.append(hrefs)
+
+            await prop.set_value("/principals/user1/", MockResource(), None)
+            self.assertEqual([[]], captured)
+
+        asyncio.run(run_test())
+
+    def test_set_value_skips_blank_hrefs(self):
+        import asyncio
+
+        async def run_test():
+            prop = caldav.CalendarProxyReadForProperty()
+            captured: list[list[str]] = []
+
+            class MockResource:
+                def set_calendar_proxy_read_for(self, hrefs):
+                    captured.append(hrefs)
+
+            el = ET.Element(prop.name)
+            ET.SubElement(el, "{DAV:}href").text = "/principals/alice/"
+            ET.SubElement(el, "{DAV:}href").text = "  "
+            ET.SubElement(el, "{DAV:}href").text = None
+
+            await prop.set_value("/principals/user1/", MockResource(), el)
+            self.assertEqual([["/principals/alice/"]], captured)
+
+        asyncio.run(run_test())
+
+
+class CalendarProxyWriteForPropertyTests(unittest.TestCase):
+    """Tests for CalendarProxyWriteForProperty."""
+
+    def test_property_name(self):
+        prop = caldav.CalendarProxyWriteForProperty()
+        self.assertEqual(
+            "{http://calendarserver.org/ns/}calendar-proxy-write-for", prop.name
+        )
+
+    def test_property_attributes(self):
+        prop = caldav.CalendarProxyWriteForProperty()
+        self.assertFalse(prop.in_allprops)
+        self.assertTrue(prop.live)
+        self.assertEqual("{DAV:}principal", prop.resource_type)
+
+    def test_get_value_emits_hrefs(self):
+        import asyncio
+
+        async def run_test():
+            prop = caldav.CalendarProxyWriteForProperty()
+
+            class MockResource:
+                def get_calendar_proxy_write_for(self):
+                    return ["/principals/alice/"]
+
+            el = ET.Element("test")
+            await prop.get_value("/principals/user1/", MockResource(), el, {})
+            hrefs = [h.text for h in el.findall("{DAV:}href")]
+            self.assertEqual(["/principals/alice/"], hrefs)
+
+        asyncio.run(run_test())
+
+    def test_set_value_extracts_hrefs(self):
+        import asyncio
+
+        async def run_test():
+            prop = caldav.CalendarProxyWriteForProperty()
+            captured: list[list[str]] = []
+
+            class MockResource:
+                def set_calendar_proxy_write_for(self, hrefs):
+                    captured.append(hrefs)
+
+            el = ET.Element(prop.name)
+            ET.SubElement(el, "{DAV:}href").text = "/principals/alice/"
+
+            await prop.set_value("/principals/user1/", MockResource(), el)
+            self.assertEqual([["/principals/alice/"]], captured)
+
+        asyncio.run(run_test())
+
+    def test_set_value_remove_clears(self):
+        import asyncio
+
+        async def run_test():
+            prop = caldav.CalendarProxyWriteForProperty()
+            captured: list[list[str]] = []
+
+            class MockResource:
+                def set_calendar_proxy_write_for(self, hrefs):
+                    captured.append(hrefs)
+
+            await prop.set_value("/principals/user1/", MockResource(), None)
+            self.assertEqual([[]], captured)
+
+        asyncio.run(run_test())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -187,6 +187,42 @@ class FileBasedPrincipalConfigTests(TestCase):
         self._config.set_calendar_home_set([])
         self.assertFalse(self._config._configparser.has_section("principal"))
 
+    def test_calendar_proxy_read_for_missing(self):
+        self.assertRaises(KeyError, self._config.get_calendar_proxy_read_for)
+
+    def test_calendar_proxy_read_for_roundtrip(self):
+        self._config.set_calendar_proxy_read_for(["/alice/"])
+        self.assertEqual(["/alice/"], self._config.get_calendar_proxy_read_for())
+
+    def test_calendar_proxy_read_for_multiple(self):
+        self._config.set_calendar_proxy_read_for(["/alice/", "/bob/"])
+        self.assertEqual(
+            ["/alice/", "/bob/"], self._config.get_calendar_proxy_read_for()
+        )
+
+    def test_calendar_proxy_read_for_unset(self):
+        self._config.set_calendar_proxy_read_for(["/alice/"])
+        self._config.set_calendar_proxy_read_for([])
+        self.assertRaises(KeyError, self._config.get_calendar_proxy_read_for)
+
+    def test_calendar_proxy_write_for_missing(self):
+        self.assertRaises(KeyError, self._config.get_calendar_proxy_write_for)
+
+    def test_calendar_proxy_write_for_roundtrip(self):
+        self._config.set_calendar_proxy_write_for(["/alice/"])
+        self.assertEqual(["/alice/"], self._config.get_calendar_proxy_write_for())
+
+    def test_calendar_proxy_write_for_multiple(self):
+        self._config.set_calendar_proxy_write_for(["/alice/", "/bob/"])
+        self.assertEqual(
+            ["/alice/", "/bob/"], self._config.get_calendar_proxy_write_for()
+        )
+
+    def test_calendar_proxy_write_for_unset(self):
+        self._config.set_calendar_proxy_write_for(["/alice/"])
+        self._config.set_calendar_proxy_write_for([])
+        self.assertRaises(KeyError, self._config.get_calendar_proxy_write_for)
+
 
 class FileMetadataTests(TestCase, MetadataTests):
     def setUp(self):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3253,6 +3253,52 @@ class PrincipalHomeSetTests(unittest.TestCase):
         self.assertIsNone(backend.get_resource("/alice/contacts"))
 
 
+class PrincipalCalendarProxyForTests(unittest.TestCase):
+    """Per-principal calendar-proxy-{read,write}-for overrides via .xandikos."""
+
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tempdir)
+        self.backend = SingleUserFilesystemBackend(self.tempdir)
+        self.backend.create_principal("/user", create_defaults=False)
+        self.principal = self.backend.get_resource("/user")
+
+    def test_defaults_when_no_config(self):
+        self.assertEqual([], self.principal.get_calendar_proxy_read_for())
+        self.assertEqual([], self.principal.get_calendar_proxy_write_for())
+
+    def test_read_for_roundtrip(self):
+        self.principal.set_calendar_proxy_read_for(["/alice/"])
+        self.assertEqual(["/alice/"], self.principal.get_calendar_proxy_read_for())
+        self.assertEqual([], self.principal.get_calendar_proxy_write_for())
+
+    def test_write_for_roundtrip(self):
+        self.principal.set_calendar_proxy_write_for(["/bob/"])
+        self.assertEqual(["/bob/"], self.principal.get_calendar_proxy_write_for())
+        self.assertEqual([], self.principal.get_calendar_proxy_read_for())
+
+    def test_multiple_hrefs(self):
+        self.principal.set_calendar_proxy_read_for(["/alice/", "/carol/"])
+        self.principal.set_calendar_proxy_write_for(["/bob/", "/dave/"])
+        self.assertEqual(
+            ["/alice/", "/carol/"], self.principal.get_calendar_proxy_read_for()
+        )
+        self.assertEqual(
+            ["/bob/", "/dave/"], self.principal.get_calendar_proxy_write_for()
+        )
+
+    def test_persists_across_lookups(self):
+        self.principal.set_calendar_proxy_read_for(["/alice/"])
+        fresh = self.backend.get_resource("/user")
+        self.assertEqual(["/alice/"], fresh.get_calendar_proxy_read_for())
+
+    def test_unset_returns_empty(self):
+        self.principal.set_calendar_proxy_read_for(["/alice/"])
+        self.principal.set_calendar_proxy_read_for([])
+        self.assertEqual([], self.principal.get_calendar_proxy_read_for())
+
+
 class FilesystemBackendMapPathTests(unittest.TestCase):
     """Tests for FilesystemBackend._map_to_file_path traversal handling."""
 

--- a/xandikos/caldav.py
+++ b/xandikos/caldav.py
@@ -947,6 +947,17 @@ class CalendarProxyReadForProperty(webdav.Property):
         for href in resource.get_calendar_proxy_read_for():
             el.append(webdav.create_href(href, base_href))
 
+    async def set_value(self, href, resource, el):
+        if el is None:
+            resource.set_calendar_proxy_read_for([])
+            return
+        hrefs = [
+            child.text.strip()
+            for child in el.findall("{DAV:}href")
+            if child.text and child.text.strip()
+        ]
+        resource.set_calendar_proxy_read_for(hrefs)
+
 
 class CalendarProxyWriteForProperty(webdav.Property):
     """calendar-proxy-write-for property.
@@ -964,6 +975,17 @@ class CalendarProxyWriteForProperty(webdav.Property):
     async def get_value(self, base_href, resource, el, environ):
         for href in resource.get_calendar_proxy_write_for():
             el.append(webdav.create_href(href, base_href))
+
+    async def set_value(self, href, resource, el):
+        if el is None:
+            resource.set_calendar_proxy_write_for([])
+            return
+        hrefs = [
+            child.text.strip()
+            for child in el.findall("{DAV:}href")
+            if child.text and child.text.strip()
+        ]
+        resource.set_calendar_proxy_write_for(hrefs)
 
 
 class ScheduleCalendarTransparencyProperty(webdav.Property):

--- a/xandikos/store/config.py
+++ b/xandikos/store/config.py
@@ -195,6 +195,42 @@ class CollectionMetadata:
         """
         raise NotImplementedError(self.set_addressbook_home_set)
 
+    def get_calendar_proxy_read_for(self) -> list[str]:
+        """Get the principals this principal is a read-only proxy for.
+
+        See the CalDAV proxy extension, section 5.3.1.
+
+        Returns: list of principal URLs.
+        Raises: KeyError if not set
+        """
+        raise NotImplementedError(self.get_calendar_proxy_read_for)
+
+    def set_calendar_proxy_read_for(self, hrefs: list[str]) -> None:
+        """Set the principals this principal is a read-only proxy for.
+
+        Args:
+            hrefs: list of principal URLs, or empty list to unset
+        """
+        raise NotImplementedError(self.set_calendar_proxy_read_for)
+
+    def get_calendar_proxy_write_for(self) -> list[str]:
+        """Get the principals this principal is a read-write proxy for.
+
+        See the CalDAV proxy extension, section 5.3.2.
+
+        Returns: list of principal URLs.
+        Raises: KeyError if not set
+        """
+        raise NotImplementedError(self.get_calendar_proxy_write_for)
+
+    def set_calendar_proxy_write_for(self, hrefs: list[str]) -> None:
+        """Set the principals this principal is a read-write proxy for.
+
+        Args:
+            hrefs: list of principal URLs, or empty list to unset
+        """
+        raise NotImplementedError(self.set_calendar_proxy_write_for)
+
     def get_resource_id(self) -> str:
         """Get the persisted DAV:resource-id UUID for this collection.
 
@@ -403,6 +439,24 @@ class FileBasedCollectionMetadata(CollectionMetadata):
         joined = ", ".join(paths) if paths else None
         self._set_principal_option(
             "addressbook-home-set", joined, "Set addressbook-home-set."
+        )
+
+    def get_calendar_proxy_read_for(self):
+        return self._get_principal_path_list("calendar-proxy-read-for")
+
+    def set_calendar_proxy_read_for(self, hrefs):
+        joined = ", ".join(hrefs) if hrefs else None
+        self._set_principal_option(
+            "calendar-proxy-read-for", joined, "Set calendar-proxy-read-for."
+        )
+
+    def get_calendar_proxy_write_for(self):
+        return self._get_principal_path_list("calendar-proxy-write-for")
+
+    def set_calendar_proxy_write_for(self, hrefs):
+        joined = ", ".join(hrefs) if hrefs else None
+        self._set_principal_option(
+            "calendar-proxy-write-for", joined, "Set calendar-proxy-write-for."
         )
 
     def get_resource_id(self):

--- a/xandikos/templates/principal.html
+++ b/xandikos/templates/principal.html
@@ -17,6 +17,26 @@
     {% endfor %}
     </ul>
 
+    {% set proxy_read_for = principal.get_calendar_proxy_read_for() %}
+    {% if proxy_read_for %}
+    <h2>Read-only proxy for</h2>
+    <ul>
+    {% for href in proxy_read_for %}
+       <li><a href="{{ urljoin(self_url+'/', href) }}">{{ href }}</a></li>
+    {% endfor %}
+    </ul>
+    {% endif %}
+
+    {% set proxy_write_for = principal.get_calendar_proxy_write_for() %}
+    {% if proxy_write_for %}
+    <h2>Read-write proxy for</h2>
+    <ul>
+    {% for href in proxy_write_for %}
+       <li><a href="{{ urljoin(self_url+'/', href) }}">{{ href }}</a></li>
+    {% endfor %}
+    </ul>
+    {% endif %}
+
     <p>For more information about Xandikos, see <a
     href="https://www.xandikos.org/">https://www.xandikos.org/</a>
     or <a href="https://github.com/jelmer/xandikos">https://github.com/jelmer/xandikos</a>.

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -2229,12 +2229,40 @@ class Principal(webdav.Principal):
         self._metadata().set_schedule_default_calendar_url(url)
 
     def get_calendar_proxy_read_for(self):
-        # TODO(jelmer)
-        return []
+        """Return principals this principal is a read-only proxy for.
+
+        Reads from the principal's ``.xandikos`` config; falls back
+        to an empty list when nothing is configured.
+        """
+        try:
+            return self._metadata().get_calendar_proxy_read_for()
+        except KeyError:
+            return []
+
+    def set_calendar_proxy_read_for(self, hrefs: list[str]) -> None:
+        """Persist the calendar-proxy-read-for list.
+
+        Pass an empty list to unset the override.
+        """
+        self._metadata().set_calendar_proxy_read_for(hrefs)
 
     def get_calendar_proxy_write_for(self):
-        # TODO(jelmer)
-        return []
+        """Return principals this principal is a read-write proxy for.
+
+        Reads from the principal's ``.xandikos`` config; falls back
+        to an empty list when nothing is configured.
+        """
+        try:
+            return self._metadata().get_calendar_proxy_write_for()
+        except KeyError:
+            return []
+
+    def set_calendar_proxy_write_for(self, hrefs: list[str]) -> None:
+        """Persist the calendar-proxy-write-for list.
+
+        Pass an empty list to unset the override.
+        """
+        self._metadata().set_calendar_proxy_write_for(hrefs)
 
     def get_owner(self):
         return None

--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -1538,12 +1538,32 @@ class Principal(Resource):
         """
         raise NotImplementedError(self.get_calendar_proxy_read_for)
 
+    def set_calendar_proxy_read_for(self, hrefs: list[str]) -> None:
+        """Set the principals this principal is a read-only proxy for.
+
+        Default raises NotImplementedError so PROPPATCH on
+        calendar-proxy-read-for returns 403 on backends that haven't
+        implemented persistent storage. Pass an empty list to remove
+        any persisted value.
+        """
+        raise NotImplementedError(self.set_calendar_proxy_read_for)
+
     def get_calendar_proxy_write_for(self) -> list[str]:
         """List principals for which this one is a write proxy.
 
         Returns: List of principal hrefs
         """
         raise NotImplementedError(self.get_calendar_proxy_write_for)
+
+    def set_calendar_proxy_write_for(self, hrefs: list[str]) -> None:
+        """Set the principals this principal is a read-write proxy for.
+
+        Default raises NotImplementedError so PROPPATCH on
+        calendar-proxy-write-for returns 403 on backends that haven't
+        implemented persistent storage. Pass an empty list to remove
+        any persisted value.
+        """
+        raise NotImplementedError(self.set_calendar_proxy_write_for)
 
     def get_schedule_inbox_url(self) -> str:
         raise NotImplementedError(self.get_schedule_inbox_url)


### PR DESCRIPTION
Persist the two lists in the principal's .xandikos config and wire them through the DAV properties (readable and settable via PROPPATCH) and the principal HTML page.

Closes: #98
Closes: #99