### PR TITLE
Ignore ``X-Remote-User`` unless the operator has explicitly declared

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+0.4.7	UNRELEASED
+
+ * Ignore ``X-Remote-User`` unless the operator has explicitly
+   declared trusted proxy addresses via ``--trust-x-remote-user-from``
+   (CLI) or ``TRUST_X_REMOTE_USER_FROM`` (WSGI). Previously the header
+   was trusted unconditionally, which let any client name their own
+   principal in multi-user mode. Reported by @archnexus707. (Jelmer Vernooĳ)
+ * Wire ``--htpasswd`` and ``--autocert`` into ``xandikos multi-user``,
+   so multi-user mode can perform HTTP Basic auth itself instead of
+   requiring an external reverse proxy. (Jelmer Vernooĳ)
+
 0.4.6	2026-08-31
 
  * Implement the RFC 5842 ``DAV:resource-id`` property. Calendar and

--- a/docs/source/reverse-proxy.rst
+++ b/docs/source/reverse-proxy.rst
@@ -13,6 +13,37 @@ If you expose Xandikos at the root of a domain, no further configuration is
 necessary. When exposing it on a different path prefix, make sure to set the
 ``--route-prefix`` argument to Xandikos appropriately.
 
+.. _reverse-proxy-x-remote-user:
+
+Passing the authenticated user to Xandikos
+------------------------------------------
+
+Multi-user mode needs to know *which* user each request belongs to.
+There are two supported ways to tell it:
+
+1. **Set the WSGI ``REMOTE_USER`` environ key.** This is what
+   authenticating WSGI middleware and uWSGI's ``router_basicauth``
+   plugin do after actually verifying credentials. Xandikos always
+   honors this key.
+
+2. **Send an ``X-Remote-User`` HTTP header** and start Xandikos with
+   ``--trust-x-remote-user-from=<IP or CIDR>`` naming the reverse
+   proxy. Xandikos will then only honor the header when the request
+   comes from one of the listed peers.
+
+.. warning::
+
+   ``X-Remote-User`` is trivially spoofable: it is an ordinary HTTP
+   header the client can set. Without ``--trust-x-remote-user-from``
+   Xandikos ignores the header entirely. When you *do* enable it, the
+   fronting proxy MUST strip or overwrite any ``X-Remote-User``
+   supplied by the client before forwarding the request; otherwise an
+   authenticated user could impersonate any other principal by adding
+   their own ``X-Remote-User: victim`` header.
+
+   The nginx and Apache snippets below show how to inject a trusted
+   ``X-Remote-User`` and clear any incoming one.
+
 .well-known
 -----------
 
@@ -37,6 +68,10 @@ the ``my-htpasswd`` secret being present and having a htpasswd like file in it.
 Example: nginx reverse proxy
 -----------------------------
 
+Start Xandikos with ``--trust-x-remote-user-from=127.0.0.1`` (or the
+address nginx connects from) so it accepts the header this config
+injects.
+
 .. code-block:: nginx
 
    server {
@@ -54,11 +89,21 @@ Example: nginx reverse proxy
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header Host $host;
+           # Tell Xandikos which authenticated user this request belongs to.
+           # $remote_user comes from auth_basic above, so it is trustworthy.
+           proxy_set_header X-Remote-User $remote_user;
+           # Refuse any X-Remote-User the client might have supplied,
+           # otherwise a valid basic-auth user could impersonate anyone.
+           proxy_set_header X-Forwarded-User "";
        }
    }
 
 Example: Apache reverse proxy
 -----------------------------
+
+Start Xandikos with ``--trust-x-remote-user-from=127.0.0.1`` (or the
+address Apache connects from) so it accepts the header this config
+injects.
 
 .. code-block:: apache
 
@@ -74,6 +119,11 @@ Example: Apache reverse proxy
            AuthName "CalDAV/CardDAV"
            AuthUserFile /etc/apache2/htdigest
            Require valid-user
+
+           # Strip any client-supplied X-Remote-User before proxying,
+           # then set it from the value Apache actually authenticated.
+           RequestHeader unset X-Remote-User
+           RequestHeader set X-Remote-User "%{REMOTE_USER}s"
 
            ProxyPass http://localhost:8080/
            ProxyPassReverse http://localhost:8080/

--- a/examples/xandikos-ingress.k8s.yaml
+++ b/examples/xandikos-ingress.k8s.yaml
@@ -6,6 +6,13 @@ metadata:
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: my-htpasswd
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - mysite'
+    # Tell Xandikos which user this request belongs to. Strip any
+    # client-supplied X-Remote-User first, then set it from the value
+    # basic auth verified above. Start Xandikos with
+    # --trust-x-remote-user-from=<ingress pod CIDR> so it honors this.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-Remote-User $remote_user;
+      proxy_set_header X-Forwarded-User "";
 spec:
   ingressClassName: nginx
   rules:

--- a/notes/auth.rst
+++ b/notes/auth.rst
@@ -13,3 +13,24 @@ environment variable.
 Per
 http://wsgi.readthedocs.io/en/latest/specifications/simple_authentication.html,
 Xandikos should distinguish between 401 and 403.
+
+Never trust ``X-Remote-User`` from an unauthenticated client
+------------------------------------------------------------
+
+Xandikos also supports being told the authenticated user via an
+``X-Remote-User`` HTTP header (and its WSGI translation
+``HTTP_X_REMOTE_USER``). This is convenient when the fronting proxy
+identifies users out of band, but by default the header is
+**ignored**: the value comes straight from the HTTP request, so any
+client could set it and pick their own principal.
+
+To opt in, pass ``--trust-x-remote-user-from=<IP or CIDR>`` (repeatable)
+on the command line, or set ``TRUST_X_REMOTE_USER_FROM`` when using
+``xandikos.wsgi``. Xandikos then only honors ``X-Remote-User`` when the
+request originates from one of the listed addresses. The upstream
+reverse proxy must additionally strip or overwrite any ``X-Remote-User``
+supplied by the client before forwarding the request.
+
+The genuine ``REMOTE_USER`` WSGI environ key -- as set by
+authenticating WSGI middleware or by uWSGI's ``router_basicauth``
+plugin -- is always honored, regardless of this setting.

--- a/notes/multi-user.rst
+++ b/notes/multi-user.rst
@@ -20,6 +20,19 @@ user. E.g. Apache or uWSGI sets the REMOTE_USER environment variable. If
 REMOTE_USER is not present for an operation that requires authentication, a 401
 error is returned.
 
+Multi-user mode also accepts the authenticated user via an
+``X-Remote-User`` HTTP header, but only when the operator has
+explicitly declared which peers are allowed to send it (via
+``--trust-x-remote-user-from``). Without that flag the header is
+ignored, because otherwise any client could pick their own principal
+simply by naming it.
+
+Alternatively, ``xandikos multi-user`` can perform HTTP Basic
+authentication itself against an htpasswd file: pass ``--htpasswd
+FILE`` together with ``--autocert`` (for a self-signed development
+TLS cert) or run behind a proxy that terminates TLS. In production
+prefer a real TLS certificate at the proxy.
+
 Authorization
 -------------
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -28,7 +28,7 @@ import warnings
 from unittest.mock import MagicMock, AsyncMock
 from wsgiref.util import setup_testing_defaults
 
-from xandikos.webdav import WebDAVApp
+from xandikos.webdav import WebDAVApp, AUTHENTICATED_USER_ATTR
 from xandikos.multi_user import MultiUserFilesystemBackend
 
 
@@ -46,143 +46,189 @@ class MockBackend:
         return self.resources.get(path)
 
 
-class AuthenticationTests(unittest.TestCase):
-    """Tests for authentication header handling."""
+def _make_aiohttp_request(header_map, *, remote=None, extras=None):
+    """Build a MagicMock modelling the aiohttp Request surface we touch."""
+    mock_request = AsyncMock()
+    mock_headers = MagicMock()
+    mock_headers.get.side_effect = lambda k, d=None: header_map.get(k, d)
+    mock_headers.__getitem__.side_effect = lambda k: header_map[k]
+    mock_headers.__contains__.side_effect = lambda k: k in header_map
+    mock_request.headers = mock_headers
+    mock_request.method = "OPTIONS"
+    mock_request.path = "/"
+    mock_request.url = "http://example.com/"
+    mock_request.raw_path = "/"
+    mock_request.match_info = {"path_info": "/"}
+    mock_request.content_type = "text/plain"
+    mock_request.content_length = 0
+    mock_request.can_read_body = False
+    mock_request.remote = remote
+
+    storage = dict(extras or {})
+    mock_request.get = storage.get
+    mock_request.__getitem__ = lambda self_, k: storage[k]
+    mock_request.__setitem__ = lambda self_, k, v: storage.__setitem__(k, v)
+    mock_request.__contains__ = lambda self_, k: k in storage
+    return mock_request
+
+
+class WSGIAuthenticationTests(unittest.TestCase):
+    """WSGI-side handling of REMOTE_USER and X-Remote-User."""
 
     def setUp(self):
         self.backend = MockBackend()
-        self.app = WebDAVApp(self.backend)
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
+
+        mock_resource = MagicMock()
+        mock_resource.resource_types = []
+        self.backend.resources["/"] = mock_resource
 
     def tearDown(self):
         self.loop.close()
         asyncio.set_event_loop(None)
 
-    def test_wsgi_x_remote_user_header(self):
-        """Test that HTTP_X_REMOTE_USER is handled in WSGI."""
-        environ = {
-            "REQUEST_METHOD": "OPTIONS",
-            "PATH_INFO": "/",
-            "HTTP_X_REMOTE_USER": "testuser",
-        }
+    def _run_wsgi(self, app, environ):
         setup_testing_defaults(environ)
-
-        # Mock the resource
-        mock_resource = MagicMock()
-        mock_resource.resource_types = []
-        self.backend.resources["/"] = mock_resource
-
-        # Mock start_response
         responses = []
 
         def start_response(status, headers):
             responses.append((status, headers))
             return lambda x: None
 
-        # Call the WSGI handler
-        list(self.app.handle_wsgi_request(environ, start_response))
+        list(app.handle_wsgi_request(environ, start_response))
+        self.assertTrue(responses)
 
-        # Check that we got a response
-        self.assertTrue(len(responses) > 0)
-
-        # Check that set_principal was called with the user
-        self.assertEqual(["testuser"], self.backend.set_principal_calls)
-
-        # Check that REMOTE_USER was set in environ for the request
-        # (The environ is recreated in handle_wsgi_request, so we can't check it directly)
-
-    def test_wsgi_no_remote_user(self):
-        """Test WSGI without authentication header."""
+    def test_genuine_remote_user_env_is_honored(self):
+        """REMOTE_USER set by an authenticating WSGI middleware is trusted."""
+        app = WebDAVApp(self.backend)
         environ = {
             "REQUEST_METHOD": "OPTIONS",
             "PATH_INFO": "/",
+            "REMOTE_USER": "wsgiuser",
         }
-        setup_testing_defaults(environ)
+        self._run_wsgi(app, environ)
+        self.assertEqual(["wsgiuser"], self.backend.set_principal_calls)
 
-        # Mock the resource
-        mock_resource = MagicMock()
-        mock_resource.resource_types = []
-        self.backend.resources["/"] = mock_resource
+    def test_http_x_remote_user_ignored_by_default(self):
+        """HTTP_X_REMOTE_USER (from a client X-Remote-User header) is ignored.
 
-        # Mock start_response
-        responses = []
-
-        def start_response(status, headers):
-            responses.append((status, headers))
-            return lambda x: None
-
-        # Call the WSGI handler
-        self.app.handle_wsgi_request(environ, start_response)
-
-        # Check that set_principal was NOT called
+        Without an explicit trust opt-in the header is client-supplied and
+        must not be allowed to name the authenticated principal (CVE-worthy
+        impersonation otherwise).
+        """
+        app = WebDAVApp(self.backend)
+        environ = {
+            "REQUEST_METHOD": "OPTIONS",
+            "PATH_INFO": "/",
+            "HTTP_X_REMOTE_USER": "attacker",
+        }
+        self._run_wsgi(app, environ)
         self.assertEqual([], self.backend.set_principal_calls)
 
-    def test_aiohttp_x_remote_user_header(self):
-        """Test that X-Remote-User header is handled in aiohttp."""
-        # Create a mock aiohttp request
-        mock_request = AsyncMock()
-        mock_headers = MagicMock()
-        mock_headers.get.side_effect = lambda k, d=None: (
-            "aiohttpuser" if k == "X-Remote-User" else d
-        )
-        mock_headers.__getitem__.side_effect = lambda k: (
-            "aiohttpuser" if k == "X-Remote-User" else None
-        )
-        mock_request.headers = mock_headers
-        mock_request.method = "OPTIONS"
-        mock_request.path = "/"
-        mock_request.url = "http://example.com/"
-        mock_request.raw_path = "/"
-        mock_request.match_info = {"path_info": "/"}
-        mock_request.content_type = "text/plain"
-        mock_request.content_length = 0
-        mock_request.can_read_body = False
+    def test_http_x_remote_user_honored_when_peer_trusted(self):
+        """With trusted-hosts + matching REMOTE_ADDR, the header is trusted."""
+        app = WebDAVApp(self.backend, trusted_x_remote_user_hosts=["10.0.0.0/8"])
+        environ = {
+            "REQUEST_METHOD": "OPTIONS",
+            "PATH_INFO": "/",
+            "HTTP_X_REMOTE_USER": "proxied",
+            "REMOTE_ADDR": "10.1.2.3",
+        }
+        self._run_wsgi(app, environ)
+        self.assertEqual(["proxied"], self.backend.set_principal_calls)
 
-        # Mock the resource
+    def test_http_x_remote_user_rejected_when_peer_untrusted(self):
+        """Trusted-hosts is a CIDR gate: a non-matching peer is rejected."""
+        app = WebDAVApp(self.backend, trusted_x_remote_user_hosts=["10.0.0.0/8"])
+        environ = {
+            "REQUEST_METHOD": "OPTIONS",
+            "PATH_INFO": "/",
+            "HTTP_X_REMOTE_USER": "attacker",
+            "REMOTE_ADDR": "192.0.2.5",
+        }
+        self._run_wsgi(app, environ)
+        self.assertEqual([], self.backend.set_principal_calls)
+
+    def test_wsgi_no_remote_user(self):
+        """Without any signal there is no authenticated principal."""
+        app = WebDAVApp(self.backend)
+        environ = {"REQUEST_METHOD": "OPTIONS", "PATH_INFO": "/"}
+        self._run_wsgi(app, environ)
+        self.assertEqual([], self.backend.set_principal_calls)
+
+
+class AiohttpAuthenticationTests(unittest.TestCase):
+    """aiohttp-side handling of X-Remote-User and in-process markers."""
+
+    def setUp(self):
+        self.backend = MockBackend()
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
         mock_resource = MagicMock()
         mock_resource.resource_types = []
         self.backend.resources["/"] = mock_resource
 
-        # Call the aiohttp handler
+    def tearDown(self):
+        self.loop.close()
+        asyncio.set_event_loop(None)
+
+    def _dispatch(self, app, request):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             warnings.simplefilter("ignore", ResourceWarning)
-            self.loop.run_until_complete(self.app.aiohttp_handler(mock_request, "/"))
+            self.loop.run_until_complete(app.aiohttp_handler(request, "/"))
             gc.collect()
 
-        # Check that set_principal was called with the user
-        self.assertEqual(["aiohttpuser"], self.backend.set_principal_calls)
+    def test_x_remote_user_header_ignored_by_default(self):
+        """Client-supplied X-Remote-User is rejected without trust config."""
+        app = WebDAVApp(self.backend)
+        request = _make_aiohttp_request(
+            {"X-Remote-User": "attacker"}, remote="203.0.113.4"
+        )
+        self._dispatch(app, request)
+        self.assertEqual([], self.backend.set_principal_calls)
+
+    def test_x_remote_user_header_honored_when_peer_trusted(self):
+        """Trusted-proxy CIDR enables the header."""
+        app = WebDAVApp(self.backend, trusted_x_remote_user_hosts=["127.0.0.0/8"])
+        request = _make_aiohttp_request(
+            {"X-Remote-User": "proxied"}, remote="127.0.0.1"
+        )
+        self._dispatch(app, request)
+        self.assertEqual(["proxied"], self.backend.set_principal_calls)
+
+    def test_x_remote_user_header_rejected_when_peer_untrusted(self):
+        """A request from outside the trusted CIDR is not honored."""
+        app = WebDAVApp(self.backend, trusted_x_remote_user_hosts=["127.0.0.0/8"])
+        request = _make_aiohttp_request(
+            {"X-Remote-User": "attacker"}, remote="198.51.100.7"
+        )
+        self._dispatch(app, request)
+        self.assertEqual([], self.backend.set_principal_calls)
+
+    def test_in_process_marker_beats_header(self):
+        """Middleware may set an in-process marker on the request.
+
+        This is the mechanism basic_auth_middleware uses. It must take
+        precedence over any client-supplied X-Remote-User (which is left
+        untrusted), so that an attacker cannot set X-Remote-User to
+        override the actually-authenticated identity.
+        """
+        app = WebDAVApp(self.backend)
+        request = _make_aiohttp_request(
+            {"X-Remote-User": "attacker"},
+            remote="203.0.113.4",
+            extras={AUTHENTICATED_USER_ATTR: "authed"},
+        )
+        self._dispatch(app, request)
+        self.assertEqual(["authed"], self.backend.set_principal_calls)
 
     def test_aiohttp_no_remote_user(self):
-        """Test aiohttp without authentication header."""
-        # Create a mock aiohttp request
-        mock_request = AsyncMock()
-        mock_headers = MagicMock()
-        mock_headers.get.return_value = None
-        mock_request.headers = mock_headers
-        mock_request.method = "OPTIONS"
-        mock_request.path = "/"
-        mock_request.url = "http://example.com/"
-        mock_request.raw_path = "/"
-        mock_request.match_info = {"path_info": "/"}
-        mock_request.content_type = "text/plain"
-        mock_request.content_length = 0
-        mock_request.can_read_body = False
-
-        # Mock the resource
-        mock_resource = MagicMock()
-        mock_resource.resource_types = []
-        self.backend.resources["/"] = mock_resource
-
-        # Call the aiohttp handler
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", RuntimeWarning)
-            warnings.simplefilter("ignore", ResourceWarning)
-            self.loop.run_until_complete(self.app.aiohttp_handler(mock_request, "/"))
-            gc.collect()
-
-        # Check that set_principal was NOT called
+        app = WebDAVApp(self.backend)
+        request = _make_aiohttp_request({}, remote="127.0.0.1")
+        self._dispatch(app, request)
         self.assertEqual([], self.backend.set_principal_calls)
 
 
@@ -199,39 +245,72 @@ class IntegrationTests(unittest.TestCase):
         self.loop.close()
         asyncio.set_event_loop(None)
 
-    def test_multiuser_backend_with_aiohttp_auth(self):
-        """Test MultiUserFilesystemBackend with aiohttp authentication."""
-        backend = MultiUserFilesystemBackend(self.d)
-        app = WebDAVApp(backend)
-
-        # Create a mock aiohttp request with auth
-        mock_request = AsyncMock()
-        mock_headers = MagicMock()
-        mock_headers.get.side_effect = lambda k, d=None: (
-            "alice" if k == "X-Remote-User" else d
-        )
-        mock_headers.__getitem__.side_effect = lambda k: (
-            "alice" if k == "X-Remote-User" else None
-        )
-        mock_request.headers = mock_headers
-        mock_request.method = "PROPFIND"
-        mock_request.path = "/alice/"
-        mock_request.url = "http://example.com/alice/"
-        mock_request.raw_path = "/alice/"
-        mock_request.match_info = {"path_info": "/alice/"}
-        mock_request.content_type = "application/xml"
-        mock_request.content_length = 0
-        mock_request.can_read_body = False
-
-        # Call the aiohttp handler
+    def _dispatch(self, app, request):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             warnings.simplefilter("ignore", ResourceWarning)
-            self.loop.run_until_complete(app.aiohttp_handler(mock_request, "/"))
+            self.loop.run_until_complete(app.aiohttp_handler(request, "/"))
             gc.collect()
 
-        # Check that the principal was created
+    def test_multiuser_rejects_untrusted_x_remote_user(self):
+        """Multi-user + no trust config: X-Remote-User cannot create alice."""
+        backend = MultiUserFilesystemBackend(self.d)
+        app = WebDAVApp(backend)
+
+        request = _make_aiohttp_request(
+            {"X-Remote-User": "alice"}, remote="203.0.113.4"
+        )
+        request.method = "PROPFIND"
+        request.path = "/alice/"
+        request.url = "http://example.com/alice/"
+        request.raw_path = "/alice/"
+        request.match_info = {"path_info": "/alice/"}
+        request.content_type = "application/xml"
+
+        self._dispatch(app, request)
+
+        # No principal was created, since the header is untrusted.
+        self.assertIsNone(backend.get_resource("/alice/"))
+        self.assertNotIn("/alice", backend._user_principals)
+
+    def test_multiuser_honors_x_remote_user_from_trusted_peer(self):
+        """Multi-user + explicit trust: header creates & auths the principal."""
+        backend = MultiUserFilesystemBackend(self.d)
+        app = WebDAVApp(backend, trusted_x_remote_user_hosts=["127.0.0.0/8", "::1"])
+
+        request = _make_aiohttp_request({"X-Remote-User": "alice"}, remote="127.0.0.1")
+        request.method = "PROPFIND"
+        request.path = "/alice/"
+        request.url = "http://example.com/alice/"
+        request.raw_path = "/alice/"
+        request.match_info = {"path_info": "/alice/"}
+        request.content_type = "application/xml"
+
+        self._dispatch(app, request)
+
         resource = backend.get_resource("/alice/")
         self.assertIsNotNone(resource)
-        # _mark_as_principal normalizes the path, removing trailing slashes
         self.assertIn("/alice", backend._user_principals)
+
+    def test_multiuser_in_process_marker_creates_principal(self):
+        """basic_auth_middleware's in-process marker also creates principals."""
+        backend = MultiUserFilesystemBackend(self.d)
+        app = WebDAVApp(backend)
+
+        request = _make_aiohttp_request(
+            {},
+            remote="203.0.113.4",
+            extras={AUTHENTICATED_USER_ATTR: "bob"},
+        )
+        request.method = "PROPFIND"
+        request.path = "/bob/"
+        request.url = "http://example.com/bob/"
+        request.raw_path = "/bob/"
+        request.match_info = {"path_info": "/bob/"}
+        request.content_type = "application/xml"
+
+        self._dispatch(app, request)
+
+        resource = backend.get_resource("/bob/")
+        self.assertIsNotNone(resource)
+        self.assertIn("/bob", backend._user_principals)

--- a/tests/test_webdav_push.py
+++ b/tests/test_webdav_push.py
@@ -1011,6 +1011,14 @@ class SubscriptionDeleteHandlerTests(unittest.IsolatedAsyncioTestCase):
         self.app = XandikosApp.__new__(XandikosApp)
         self.app.backend = self.backend
         self.app.extra_features = [webdav_push.FEATURE]
+        # Delete handler now routes X-Remote-User through the same trust
+        # check WebDAVApp uses. Tests here exercise header forwarding, so
+        # trust the loopback range that the fake requests come from.
+        from xandikos.webdav import _parse_trusted_hosts
+
+        self.app.trusted_x_remote_user_hosts = _parse_trusted_hosts(
+            ["0.0.0.0/0", "::/0"]
+        )
 
         self._prev_index = webdav_push._index
         webdav_push._index = webdav_push.SubscriptionIndex(self.state_dir)
@@ -1040,6 +1048,7 @@ class SubscriptionDeleteHandlerTests(unittest.IsolatedAsyncioTestCase):
             def __init__(self, sub_id, headers):
                 self.match_info = {"sub_id": sub_id}
                 self.headers = headers or {}
+                self.remote = "127.0.0.1"
 
         handler = _make_subscription_delete_handler(self.app)
         return await handler(_Request(sub_id, headers))

--- a/xandikos/multi_user.py
+++ b/xandikos/multi_user.py
@@ -29,12 +29,14 @@ import logging
 import os
 import posixpath
 import signal
+from collections.abc import Iterable
 
 from .web import (
     SingleUserFilesystemBackend,
     XandikosApp,
     WELLKNOWN_DAV_PATHS,
     RedirectDavHandler,
+    basic_auth_middleware,
     get_systemd_listen_sockets,
     systemd_imported,
 )
@@ -150,6 +152,7 @@ class MultiUserXandikosApp(XandikosApp):
         require_auth: bool = True,
         vapid_keystore=None,
         state_dir: str | None = None,
+        trusted_x_remote_user_hosts: Iterable[str] | None = None,
     ) -> None:
         """Initialize the multi-user app.
 
@@ -162,6 +165,10 @@ class MultiUserXandikosApp(XandikosApp):
             vapid_keystore: Optional VAPID keystore enabling WebDAV-Push.
             state_dir: Xandikos server state directory; required if
                 ``vapid_keystore`` is provided.
+            trusted_x_remote_user_hosts: See
+                :class:`xandikos.webdav.WebDAVApp`. Off by default so
+                that no client-supplied header can override the
+                authenticated principal.
         """
         super().__init__(
             backend,
@@ -169,6 +176,7 @@ class MultiUserXandikosApp(XandikosApp):
             strict=strict,
             vapid_keystore=vapid_keystore,
             state_dir=state_dir,
+            trusted_x_remote_user_hosts=trusted_x_remote_user_hosts,
         )
         self._backend = backend
         self._require_auth = require_auth
@@ -320,6 +328,47 @@ def add_parser(parser):
             "[%(default)s]"
         ),
     )
+    access_group.add_argument(
+        "--autocert",
+        action="store_true",
+        help=(
+            "Serve HTTPS using a self-signed certificate, generating one "
+            "under <state-dir>/certs if missing. "
+            "For development and testing only - do not use in production."
+        ),
+    )
+    access_group.add_argument(
+        "--htpasswd",
+        dest="htpasswd",
+        default=None,
+        metavar="FILE",
+        help=(
+            "Require HTTP Basic authentication using credentials from the "
+            "given Apache-style htpasswd file. bcrypt entries (htpasswd -B) "
+            "are recommended. Requires --autocert: Basic auth sends "
+            "credentials in cleartext and must not be served over plain "
+            "HTTP. If you run Xandikos behind a reverse proxy, configure "
+            "authentication there instead of using this flag."
+        ),
+    )
+    access_group.add_argument(
+        "--trust-x-remote-user-from",
+        dest="trust_x_remote_user_from",
+        action="append",
+        default=None,
+        metavar="ADDR/CIDR",
+        help=(
+            "Trust the X-Remote-User HTTP header (and its WSGI "
+            "translation HTTP_X_REMOTE_USER) when the request "
+            "originates from this IP address or CIDR block. May be "
+            "given multiple times. Without this flag the header is "
+            "IGNORED, because a client can send it directly and thereby "
+            "impersonate any principal. Only use this flag when Xandikos "
+            "sits behind a reverse proxy that (a) authenticates the "
+            "user itself and (b) strips or overwrites any incoming "
+            "X-Remote-User header before forwarding the request."
+        ),
+    )
     parser.add_argument(
         "-d",
         "--directory",
@@ -455,6 +504,7 @@ async def main(options, parser):
         strict=options.strict,
         vapid_keystore=vapid_keystore,
         state_dir=state_dir,
+        trusted_x_remote_user_hosts=options.trust_x_remote_user_from,
     )
 
     async def xandikos_handler(request):
@@ -491,6 +541,49 @@ async def main(options, parser):
 
     from aiohttp import web
 
+    ssl_context = None
+    if options.autocert:
+        logging.warning(
+            "--autocert is enabled. The generated certificate is self-signed "
+            "and intended for development or testing only. Do NOT use this "
+            "in production; instead, run Xandikos behind a reverse proxy "
+            "(e.g. nginx, Apache, or Caddy) that terminates TLS using a "
+            "certificate from a trusted CA such as Let's Encrypt."
+        )
+        if socket_path is not None:
+            parser.error("--autocert cannot be combined with a unix domain socket")
+        if listen_socks:
+            parser.error("--autocert cannot be combined with systemd socket activation")
+        from . import autocert as autocert_mod
+
+        try:
+            cert_path, key_path = autocert_mod.ensure_self_signed(
+                os.path.join(state_dir, "certs"),
+                hostname=listen_address or "localhost",
+            )
+        except RuntimeError as exc:
+            parser.error(str(exc))
+        ssl_context = autocert_mod.make_ssl_context(cert_path, key_path)
+
+    htpasswd_file = None
+    if options.htpasswd:
+        if ssl_context is None:
+            parser.error(
+                "--htpasswd requires --autocert. Basic authentication sends "
+                "credentials in cleartext and must not be served over plain "
+                "HTTP. If you are running Xandikos behind a reverse proxy, "
+                "configure authentication at the proxy instead."
+            )
+        from . import htpasswd as htpasswd_mod
+
+        try:
+            htpasswd_file = htpasswd_mod.HtpasswdFile(options.htpasswd)
+        except htpasswd_mod.HtpasswdError as exc:
+            parser.error(str(exc))
+        logging.info(
+            "HTTP Basic authentication enabled (htpasswd: %s)", options.htpasswd
+        )
+
     if options.metrics_port == options.port:
         parser.error("Metrics port cannot be the same as the main port")
 
@@ -523,6 +616,8 @@ async def main(options, parser):
 
     if options.route_prefix.strip("/"):
         xandikos_app = web.Application()
+        if htpasswd_file is not None:
+            xandikos_app.middlewares.append(basic_auth_middleware(htpasswd_file))
         _maybe_mount_subscription_route(xandikos_app, main_app)
         xandikos_app.router.add_route("*", "/{path_info:.*}", xandikos_handler)
 
@@ -532,6 +627,8 @@ async def main(options, parser):
         app.router.add_route("*", "/", redirect_to_subprefix)
         app.add_subapp(options.route_prefix, xandikos_app)
     else:
+        if htpasswd_file is not None:
+            app.middlewares.append(basic_auth_middleware(htpasswd_file))
         _maybe_mount_subscription_route(app, main_app)
         app.router.add_route("*", "/{path_info:.*}", xandikos_handler)
 
@@ -561,7 +658,9 @@ async def main(options, parser):
     elif socket_path:
         sites.append(web.UnixSite(runner, socket_path))
     else:
-        sites.append(web.TCPSite(runner, listen_address, listen_port))
+        sites.append(
+            web.TCPSite(runner, listen_address, listen_port, ssl_context=ssl_context)
+        )
 
     loop = asyncio.get_running_loop()
     shutdown_event = asyncio.Event()

--- a/xandikos/web.py
+++ b/xandikos/web.py
@@ -2471,8 +2471,13 @@ class XandikosApp(webdav.WebDAVApp):
         strict=True,
         vapid_keystore: "webdav_push.VapidKeystore | None" = None,
         state_dir: str | None = None,
+        trusted_x_remote_user_hosts: Iterable[str] | None = None,
     ) -> None:
-        super().__init__(backend, strict=strict)
+        super().__init__(
+            backend,
+            strict=strict,
+            trusted_x_remote_user_hosts=trusted_x_remote_user_hosts,
+        )
         self.state_dir = state_dir
 
         def get_current_user_principal(env):
@@ -2662,9 +2667,12 @@ def _make_subscription_delete_handler(main_app: "XandikosApp"):
     async def handler(request):
         sub_id = request.match_info["sub_id"]
         # Mirror what WebDAVApp._handle_request does for REMOTE_USER so
-        # check_access sees the authenticated principal.
+        # check_access sees the authenticated principal. Route the
+        # header through the same trust check WebDAVApp uses; a raw
+        # X-Remote-User is only honored if the operator has explicitly
+        # trusted the peer's address.
         environ: dict = {"SCRIPT_NAME": ""}
-        remote_user = request.headers.get("X-Remote-User")
+        remote_user = main_app._resolve_remote_user(request, environ)
         if remote_user and hasattr(main_app.backend, "set_principal"):
             environ["REMOTE_USER"] = remote_user
             main_app.backend.set_principal(remote_user)
@@ -2845,12 +2853,15 @@ def basic_auth_middleware(htpasswd_file):
         except htpasswd_mod.HtpasswdError as exc:
             logger.error("htpasswd check failed: %s", exc)
             return web.Response(status=500, text="Authentication misconfigured.\n")
-        # Propagate the authenticated user to the WebDAV layer, which reads
-        # X-Remote-User the same way it would behind a reverse proxy.
-        new_request = request.clone(
-            headers={**request.headers, "X-Remote-User": username}
-        )
-        return await handler(new_request)
+        # Propagate the authenticated user to the WebDAV layer via an
+        # in-process attribute on the request. Do NOT stash it in
+        # X-Remote-User: that would tell WebDAVApp to trust an HTTP
+        # header, which is exactly the class of bug this middleware
+        # exists to avoid (a client could pre-set it to impersonate
+        # another principal). WebDAVApp reads AUTHENTICATED_USER_ATTR
+        # before consulting any headers.
+        request[webdav.AUTHENTICATED_USER_ATTR] = username
+        return await handler(request)
 
     return middleware
 
@@ -2937,6 +2948,24 @@ def add_parser(parser):
             "credentials in cleartext and must not be served over plain "
             "HTTP. If you run Xandikos behind a reverse proxy, configure "
             "authentication there instead of using this flag."
+        ),
+    )
+    access_group.add_argument(
+        "--trust-x-remote-user-from",
+        dest="trust_x_remote_user_from",
+        action="append",
+        default=None,
+        metavar="ADDR/CIDR",
+        help=(
+            "Trust the X-Remote-User HTTP header (and its WSGI "
+            "translation HTTP_X_REMOTE_USER) when the request "
+            "originates from this IP address or CIDR block. May be "
+            "given multiple times. Without this flag the header is "
+            "IGNORED, because a client can send it directly and thereby "
+            "impersonate any principal. Only use this flag when Xandikos "
+            "sits behind a reverse proxy that (a) authenticates the "
+            "user itself and (b) strips or overwrites any incoming "
+            "X-Remote-User header before forwarding the request."
         ),
     )
     parser.add_argument(
@@ -3087,6 +3116,7 @@ async def main(options, parser):
         strict=options.strict,
         vapid_keystore=vapid_keystore,
         state_dir=state_dir,
+        trusted_x_remote_user_hosts=getattr(options, "trust_x_remote_user_from", None),
     )
 
     async def xandikos_handler(request):

--- a/xandikos/webdav.py
+++ b/xandikos/webdav.py
@@ -29,6 +29,7 @@ import asyncio
 import collections
 import fnmatch
 import functools
+import ipaddress
 from logging import getLogger
 import os
 import posixpath
@@ -3562,15 +3563,73 @@ class WSGIRequest:
         return self._environ["wsgi.input"].read()
 
 
+# Sentinel that in-process middleware (e.g. basic_auth_middleware) attaches
+# to an aiohttp request to communicate an authenticated principal to
+# WebDAVApp without going through client-controllable HTTP headers.
+AUTHENTICATED_USER_ATTR = "xandikos.authenticated_user"
+
+
+def _parse_trusted_hosts(
+    hosts: Iterable[str] | None,
+) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network] | None:
+    """Parse trusted-host entries into a list of IP networks.
+
+    Each entry may be a bare address (``"127.0.0.1"``, ``"::1"``) or a CIDR
+    (``"10.0.0.0/8"``). Returns ``None`` when ``hosts`` is ``None`` (meaning
+    "no trust"); returns an empty list when the iterable is empty.
+    """
+    if hosts is None:
+        return None
+    result: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for entry in hosts:
+        result.append(ipaddress.ip_network(entry, strict=False))
+    return result
+
+
+def _peer_in_trusted_hosts(
+    peer: str | None,
+    trusted: list[ipaddress.IPv4Network | ipaddress.IPv6Network] | None,
+) -> bool:
+    """Return True if ``peer`` is inside any of the trusted networks."""
+    if not trusted or not peer:
+        return False
+    try:
+        addr = ipaddress.ip_address(peer)
+    except ValueError:
+        return False
+    return any(addr in network for network in trusted)
+
+
 class WebDAVApp:
     """A wsgi App that provides a WebDAV server.
 
     A concrete implementation should provide an implementation of the
     lookup_resource function that can map a path to a Resource object
     (returning None for nonexistent objects).
+
+    Args:
+        backend: The storage backend.
+        strict: If True, be strict about DAV compliance.
+        trusted_x_remote_user_hosts: Iterable of IP addresses or CIDR
+            networks whose ``X-Remote-User`` header (and its WSGI
+            translation ``HTTP_X_REMOTE_USER``) should be honored as the
+            authenticated principal. When ``None`` (the default) the
+            header is ignored entirely: authenticated identity must come
+            either from ``REMOTE_USER`` in the WSGI environ (set by an
+            authenticating WSGI middleware or the upstream proxy) or from
+            in-process middleware such as :func:`basic_auth_middleware`.
+            Setting this to a permissive value such as ``["0.0.0.0/0"]``
+            re-enables the pre-fix behavior and lets any client choose
+            their own principal - only do so behind a reverse proxy that
+            strips or overwrites ``X-Remote-User`` before forwarding.
     """
 
-    def __init__(self, backend, strict=True) -> None:
+    def __init__(
+        self,
+        backend,
+        strict=True,
+        trusted_x_remote_user_hosts: Iterable[str] | None = None,
+    ) -> None:
         self.backend = backend
         self.properties: dict[str, type[Property]] = {}
         self.reporters: dict[str, type[Reporter]] = {}
@@ -3581,6 +3640,9 @@ class WebDAVApp:
         # discriminator, not the URL or method.
         self.post_handlers: dict[str, Callable] = {}
         self.strict = strict
+        self.trusted_x_remote_user_hosts = _parse_trusted_hosts(
+            trusted_x_remote_user_hosts
+        )
         self.extra_features: list[str] = []
         self.register_methods(
             [
@@ -3673,16 +3735,64 @@ class WebDAVApp:
         # Default implementation allows all access
         pass
 
-    async def _handle_request(self, request, environ, start_response=None):
-        # Handle remote user authentication
-        remote_user = None
-        if hasattr(request, "headers"):
-            # aiohttp request
-            remote_user = request.headers.get("X-Remote-User")
+    def _resolve_remote_user(self, request, environ) -> str | None:
+        """Determine the authenticated principal for a request.
 
+        Order of preference:
+
+        1. An in-process marker set by trusted middleware (e.g.
+           :func:`basic_auth_middleware`). This cannot be forged by a
+           client because it lives on the request object, not in
+           headers.
+        2. ``REMOTE_USER`` already present in the WSGI environ. This is
+           the value an authenticating WSGI middleware, uWSGI's
+           ``router_basicauth`` plugin, or a reverse proxy that speaks
+           the CGI-style ``REMOTE_USER`` variable will set after
+           actually verifying credentials.
+        3. The ``X-Remote-User`` HTTP header (or its WSGI translation
+           ``HTTP_X_REMOTE_USER``) - but *only* if the peer address is
+           inside :attr:`trusted_x_remote_user_hosts`. Without an
+           explicit opt-in this branch is never taken, because the
+           header is client-controllable and would otherwise allow
+           trivial impersonation of any principal.
+        """
+        marker = None
+        if hasattr(request, "get"):
+            try:
+                marker = request.get(AUTHENTICATED_USER_ATTR)
+            except TypeError:
+                marker = None
+        if marker:
+            return marker
+
+        env_user = environ.get("REMOTE_USER")
+        if env_user:
+            return env_user
         if "ORIGINAL_ENVIRON" in environ:
-            # WSGI request
-            remote_user = environ["ORIGINAL_ENVIRON"].get("HTTP_X_REMOTE_USER")
+            env_user = environ["ORIGINAL_ENVIRON"].get("REMOTE_USER")
+            if env_user:
+                return env_user
+
+        if not self.trusted_x_remote_user_hosts:
+            return None
+
+        peer = None
+        if hasattr(request, "remote"):
+            peer = request.remote
+        if peer is None and "ORIGINAL_ENVIRON" in environ:
+            peer = environ["ORIGINAL_ENVIRON"].get("REMOTE_ADDR")
+        if not _peer_in_trusted_hosts(peer, self.trusted_x_remote_user_hosts):
+            return None
+
+        header_user = None
+        if hasattr(request, "headers"):
+            header_user = request.headers.get("X-Remote-User")
+        if not header_user and "ORIGINAL_ENVIRON" in environ:
+            header_user = environ["ORIGINAL_ENVIRON"].get("HTTP_X_REMOTE_USER")
+        return header_user or None
+
+    async def _handle_request(self, request, environ, start_response=None):
+        remote_user = self._resolve_remote_user(request, environ)
 
         if remote_user and hasattr(self.backend, "set_principal"):
             environ["REMOTE_USER"] = remote_user

--- a/xandikos/wsgi.py
+++ b/xandikos/wsgi.py
@@ -67,4 +67,17 @@ if not backend.get_resource(current_user_principal):
         )
 
 backend._mark_as_principal(current_user_principal)
-app = XandikosApp(backend, current_user_principal)
+
+# Trust incoming X-Remote-User headers only when the operator explicitly
+# opts in via TRUST_X_REMOTE_USER_FROM (comma-separated IPs/CIDRs). The
+# genuine REMOTE_USER environ key set by an authenticating WSGI
+# middleware or the upstream server is always honored regardless.
+trust_from_env = os.environ.get("TRUST_X_REMOTE_USER_FROM")
+trust_from = (
+    [entry.strip() for entry in trust_from_env.split(",") if entry.strip()]
+    if trust_from_env
+    else None
+)
+app = XandikosApp(
+    backend, current_user_principal, trusted_x_remote_user_hosts=trust_from
+)


### PR DESCRIPTION
trusted proxy addresses via ``--trust-x-remote-user-from`` (CLI) or ``TRUST_X_REMOTE_USER_FROM`` (WSGI)

Reported by @archnexus707

Also wire ``--htpasswd`` and ``--autocert`` into ``xandikos multi-user``, so multi-user mode can perform HTTP Basic auth itself instead of requiring an external reverse proxy.