### PR TITLE
Don't install tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ xandikos-milter = "xandikos.milter:cli_main"
 include-package-data = false
 
 [tool.setuptools.packages]
-find = {namespaces = false, exclude = ["benchmarks*"]}
+find = {namespaces = false, exclude = ["benchmarks*", "tests*"]}
 
 [tool.setuptools.package-data]
 xandikos = [


### PR DESCRIPTION
These end up in /usr/lib/python3.14/site-packages/tests/ for downstream distributions.